### PR TITLE
feat(*): 添加多架构构建脚本支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "dev": "concurrently -k \"cross-env VITE_DEV_SERVER_URL=http://localhost:5173 pnpm run start:electron\" \"vite\"",
     "start:electron": "pnpm run build:preload && pnpm run build:main && electron dist-electron/main/index.js",
     "dist": "pnpm run build && electron-builder",
-    "dist:mac": "cross-env ELECTRON_BUILDER_PLATFORM=darwin pnpm run dist"
+    "dist:mac-x64": "cross-env ELECTRON_BUILDER_ARCH=x64 pnpm run build && electron-builder --mac",
+    "dist:mac-arm64": "cross-env ELECTRON_BUILDER_ARCH=arm64 pnpm run build && electron-builder --mac",
+    "dist:linux-x64": "cross-env ELECTRON_BUILDER_ARCH=x64 pnpm run build && electron-builder --linux",
+    "dist:linux-arm64": "cross-env ELECTRON_BUILDER_ARCH=arm64 pnpm run build && electron-builder --linux"
   },
   "main": "dist-electron/main/index.js",
   "keywords": [],


### PR DESCRIPTION
## 变更内容

- 添加 macOS x64 和 arm64 构建脚本
- 添加 Linux x64 和 arm64 构建脚本  
- 替换原有的 dist:mac 脚本为更具体的架构支持

## 解决的问题

为项目提供更细粒度的构建选项，支持不同架构的打包需求。

## 测试

- [ ✅ ] macOS x64 构建测试
- [ ✅ ] macOS arm64 构建测试
- [ ❌ ] Linux x64 构建测试
- [ ❌ ] Linux arm64 构建测试