### PR TITLE
feat: 添加 GitHub Actions 自动发布工作流和 macOS 打包修复

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      - name: Configure Git for HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build application
         run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,6 @@ jobs:
             platform: win
             arch: x64
             script: dist:win-x64
-          
-          # Linux 构建 (支持 arm64 和 x64)
-          - os: ubuntu-latest
-            platform: linux
-            arch: x64
-            script: dist:linux-x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: arm64
-            script: dist:linux-arm64
 
     steps:
       - name: Checkout code
@@ -80,7 +70,6 @@ jobs:
           pnpm run ${{ matrix.script }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: electron-builder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -127,14 +116,11 @@ jobs:
             - **macOS Intel**: `MilkUp-${{ github.ref_name }}-mac-x64.dmg`
             - **macOS Apple Silicon**: `MilkUp-${{ github.ref_name }}-mac-arm64.dmg`  
             - **Windows x64**: `MilkUp-${{ github.ref_name }}-win-x64.exe`
-            - **Linux x64**: `MilkUp-${{ github.ref_name }}-linux-x64.AppImage`
-            - **Linux ARM64**: `MilkUp-${{ github.ref_name }}-linux-arm64.AppImage`
             
             ### 更新内容
             请查看 commit 历史了解详细更新内容。
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.exe
-            artifacts/**/*.AppImage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*' # 当推送以 v 开头的标签时触发，如 v1.0.0
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        include:
+          # macOS 构建 (支持 arm64 和 x64)
+          - os: macos-latest
+            platform: mac
+            arch: x64
+            script: dist:mac-x64
+          - os: macos-latest
+            platform: mac
+            arch: arm64
+            script: dist:mac-arm64
+          
+          # Windows 构建 (x64)
+          - os: windows-latest
+            platform: win
+            arch: x64
+            script: dist:win-x64
+          
+          # Linux 构建 (支持 arm64 和 x64)
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            script: dist:linux-x64
+          - os: ubuntu-latest
+            platform: linux
+            arch: arm64
+            script: dist:linux-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        run: pnpm run ${{ matrix.script }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MilkUp-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/*.dmg
+            dist/*.exe
+            dist/*.AppImage
+            dist/*.blockmap
+            dist/latest*.yml
+          retention-days: 5
+
+  # 创建 GitHub Release 并上传所有构建产物
+  create-release:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display structure of downloaded files
+        run: find artifacts -type f -name "*" | head -20
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: MilkUp ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          body: |
+            ## MilkUp ${{ github.ref_name }}
+            
+            ### 下载说明
+            - **macOS Intel**: `MilkUp-${{ github.ref_name }}-mac-x64.dmg`
+            - **macOS Apple Silicon**: `MilkUp-${{ github.ref_name }}-mac-arm64.dmg`  
+            - **Windows x64**: `MilkUp-${{ github.ref_name }}-win-x64.exe`
+            - **Linux x64**: `MilkUp-${{ github.ref_name }}-linux-x64.AppImage`
+            - **Linux ARM64**: `MilkUp-${{ github.ref_name }}-linux-arm64.AppImage`
+            
+            ### 更新内容
+            请查看 commit 历史了解详细更新内容。
+          files: |
+            artifacts/**/*.dmg
+            artifacts/**/*.exe
+            artifacts/**/*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     
     strategy:
       matrix:
@@ -69,12 +70,17 @@ jobs:
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: |
+          pnpm install --no-frozen-lockfile
+          pnpm rebuild
 
       - name: Build application
-        run: pnpm run ${{ matrix.script }}
+        run: |
+          echo "Building for ${{ matrix.platform }}-${{ matrix.arch }}"
+          pnpm run ${{ matrix.script }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEBUG: electron-builder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,16 +71,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifacts
+      - name: Upload artifacts (macOS x64)
+        if: matrix.platform == 'mac' && matrix.arch == 'x64'
         uses: actions/upload-artifact@v4
         with:
           name: MilkUp-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
-            dist/*.dmg
-            dist/*.exe
-            dist/*.AppImage
-            dist/*.blockmap
-            dist/latest*.yml
+            dist/MilkUp-0.0.4.dmg
+            dist/MilkUp-0.0.4.dmg.blockmap
+            dist/latest-mac.yml
+          retention-days: 5
+
+      - name: Upload artifacts (macOS arm64)
+        if: matrix.platform == 'mac' && matrix.arch == 'arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: MilkUp-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/MilkUp-0.0.4-arm64.dmg
+            dist/MilkUp-0.0.4-arm64.dmg.blockmap
+            dist/latest-mac.yml
+          retention-days: 5
+
+      - name: Upload artifacts (Windows)
+        if: matrix.platform == 'win'
+        uses: actions/upload-artifact@v4
+        with:
+          name: MilkUp-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/MilkUp Setup 0.0.4.exe
+            dist/MilkUp Setup 0.0.4.exe.blockmap
+            dist/latest.yml
           retention-days: 5
 
   # 创建 GitHub Release 并上传所有构建产物
@@ -100,7 +121,22 @@ jobs:
           path: artifacts
 
       - name: Display structure of downloaded files
-        run: find artifacts -type f \( -name "*.dmg" -o -name "*.exe" \) | sort
+        run: |
+          echo "=== Artifacts structure ==="
+          find artifacts -type f | sort
+          echo "=== DMG files ==="
+          find artifacts -name "*.dmg" | sort
+          echo "=== EXE files ==="
+          find artifacts -name "*.exe" | sort
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release_files
+          # Copy unique files to avoid duplicates
+          find artifacts -name "*.dmg" -exec cp {} release_files/ \;
+          find artifacts -name "*.exe" -exec cp {} release_files/ \;
+          echo "=== Release files ==="
+          ls -la release_files/
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -119,9 +155,6 @@ jobs:
             
             ### 更新内容
             请查看 commit 历史了解详细更新内容。
-          files: |
-            artifacts/MilkUp-mac-x64/*.dmg
-            artifacts/MilkUp-mac-arm64/*.dmg
-            artifacts/MilkUp-win-x64/*.exe
+          files: release_files/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           path: artifacts
 
       - name: Display structure of downloaded files
-        run: find artifacts -type f -name "*" | head -20
+        run: find artifacts -type f \( -name "*.dmg" -o -name "*.exe" \) | sort
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -113,14 +113,15 @@ jobs:
             ## MilkUp ${{ github.ref_name }}
             
             ### 下载说明
-            - **macOS Intel**: `MilkUp-${{ github.ref_name }}-mac-x64.dmg`
-            - **macOS Apple Silicon**: `MilkUp-${{ github.ref_name }}-mac-arm64.dmg`  
-            - **Windows x64**: `MilkUp-${{ github.ref_name }}-win-x64.exe`
+            - **macOS Intel**: 下载 DMG 文件（不含 arm64 后缀）
+            - **macOS Apple Silicon**: 下载带 arm64 后缀的 DMG 文件
+            - **Windows x64**: 下载 EXE 安装文件
             
             ### 更新内容
             请查看 commit 历史了解详细更新内容。
           files: |
-            artifacts/**/*.dmg
-            artifacts/**/*.exe
+            artifacts/MilkUp-mac-x64/*.dmg
+            artifacts/MilkUp-mac-arm64/*.dmg
+            artifacts/MilkUp-win-x64/*.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 10.13.1
 
       - name: Get pnpm store directory
         shell: bash

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "dev": "concurrently -k \"cross-env VITE_DEV_SERVER_URL=http://localhost:5173 pnpm run start:electron\" \"vite\"",
     "start:electron": "pnpm run build:preload && pnpm run build:main && electron dist-electron/main/index.js",
     "dist": "pnpm run build && electron-builder",
-    "dist:mac-x64": "cross-env ELECTRON_BUILDER_ARCH=x64 pnpm run build && electron-builder --mac",
-    "dist:mac-arm64": "cross-env ELECTRON_BUILDER_ARCH=arm64 pnpm run build && electron-builder --mac",
-    "dist:linux-x64": "cross-env ELECTRON_BUILDER_ARCH=x64 pnpm run build && electron-builder --linux",
-    "dist:linux-arm64": "cross-env ELECTRON_BUILDER_ARCH=arm64 pnpm run build && electron-builder --linux"
+    "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",
+    "dist:mac-arm64": "pnpm run build && electron-builder --mac --arm64",
+    "dist:linux-x64": "pnpm run build && electron-builder --linux --x64",
+    "dist:linux-arm64": "pnpm run build && electron-builder --linux --arm64",
+    "dist:win-x64": "pnpm run build && electron-builder --win --x64"
   },
   "main": "dist-electron/main/index.js",
   "keywords": [],
@@ -53,10 +54,20 @@
       "allowToChangeInstallationDirectory": true
     },
     "win": {
-      "target": "nsis"
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        }
+      ]
     },
     "mac": {
-      "target": "dmg"
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["x64", "arm64"]
+        }
+      ]
     },
     "linux": {
       "target": "AppImage"

--- a/package.json
+++ b/package.json
@@ -22,15 +22,7 @@
   "pnpm": {
     "overrides": {
       "@codemirror/state": "^6.2.0"
-    },
-    "onlyBuiltDependencies": [
-      "electron"
-    ],
-    "ignoredBuiltDependencies": [
-      "electron",
-      "electron-winstaller",
-      "esbuild"
-    ]
+    }
   },
   "build": {
     "appId": "com.auto-plugin.milkup",


### PR DESCRIPTION
## 🚀 功能概述

本 PR 添加了完整的 GitHub Actions 自动发布工作流，并修复了 macOS 应用打包问题。

## ✨ 主要功能

### 1. GitHub Actions 自动发布工作流
- 🎯 **触发条件**: 推送以 `v` 开头的 tag 时自动触发
- 🏗️ **多平台构建**: 支持 macOS (Intel/Apple Silicon) 和 Windows x64
- 📦 **自动发布**: 构建完成后自动创建 GitHub Release 并上传安装包

### 2. macOS 打包修复
- 🔧 **修复 x64 打包问题**: 解决了 macOS x64 架构打包仍然生成 arm64 版本的问题
- ⚙️ **多架构支持**: 正确生成 Intel 和 Apple Silicon 两个版本
- 📋 **构建脚本优化**: 更新了 package.json 中的打包脚本

### 3. 构建环境优化
- 🌟 **环境统一**: GitHub Actions 使用 Node.js v22 + pnpm 10.13.1，与本地环境一致
- 🔄 **依赖管理**: 修复了 Git SSH 权限问题和依赖安装问题
- 🚫 **移除冗余配置**: 清理了可能导致构建问题的 pnpm 配置

## 🎯 构建矩阵

| 平台 | 架构 | 输出文件 |
|------|------|----------|
| macOS | Intel (x64) | `MilkUp-[版本].dmg` |
| macOS | Apple Silicon (arm64) | `MilkUp-[版本]-arm64.dmg` |
| Windows | x64 | `MilkUp Setup [版本].exe` |

## 🔧 使用方法

1. **创建发布**: 推送 tag（如 `git tag v1.0.0 && git push origin v1.0.0`）
2. **自动构建**: GitHub Actions 自动开始多平台构建
3. **获取安装包**: 在 Releases 页面下载对应平台的安装包

## ✅ 测试状态

- ✅ 本地构建测试通过
- ✅ GitHub Actions 构建测试通过  
- ✅ 多平台安装包生成正常
- ✅ 自动发布流程验证完成

## 📝 更新日志

- 添加完整的 GitHub Actions 工作流配置
- 修复 macOS x64 打包架构问题
- 优化构建环境和依赖管理
- 简化构建平台，专注主要用户群体
- 修复文件上传重复问题

这个 PR 为项目带来了完整的自动化发布能力，大大简化了多平台应用的发布流程。