### PR TITLE
fix: 修复GitHub Action release workflow问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,7 @@ jobs:
       - name: Build application
         run: |
           echo "Building for ${{ matrix.platform }}-${{ matrix.arch }}"
-          pnpm run ${{ matrix.script }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pnpm run build && pnpm exec electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish=never
 
       - name: Upload artifacts (macOS x64)
         if: matrix.platform == 'mac' && matrix.arch == 'x64'


### PR DESCRIPTION
## 问题描述
之前的GitHub Action workflow在创建release时存在以下问题：
1. 重复创建release（electron-builder和workflow都创建）
2. 构建失败（electron-builder命令找不到）
3. 权限问题导致发布失败

## 解决方案
- 移除构建步骤中的GH_TOKEN环境变量，避免electron-builder自动发布
- 使用`pnpm exec electron-builder`确保命令可找到
- 添加`--publish=never`参数禁用自动发布功能
- 确保只有workflow的create-release job创建release

## 测试结果
已通过多个Beta标签测试验证，现在可以：
- ✅ 成功构建macOS和Windows版本
- ✅ 只创建一个release（不重复）
- ✅ 正确上传构建产物到release

## 文件变更
只修改了`.github/workflows/release.yml`文件，其他文件保持与upstream一致。

## 技术细节
```diff
- pnpm run ${{ matrix.script }}
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ pnpm run build && pnpm exec electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish=never
```