### PR TITLE
chore(nodejs): 指定nodejs版本

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 electron_mirror=https://npmmirror.com/mirrors/electron/
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "milkup"
   ],
   "main": "dist-electron/main/index.js",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --external:electron --outfile=dist-electron/main/index.js",
     "build:preload": "esbuild src/preload.ts --bundle --platform=neutral --outfile=dist-electron/preload.js --external:electron --format=cjs",


### PR DESCRIPTION
- 为了开发的统一性，强制指定nodejs版本