### PR TITLE
feat(renderer): 实现关闭前确认对话框并优化保存逻辑

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,16 +1,20 @@
 {
   "words": [
-    "asar",
     "antfu",
+    "asar",
     "autolog",
     "automd",
     "commonmark",
-    "oxlint",
+    "iconfont",
+    "mdast",
     "milkdown",
     "Milkdown",
     "milkup",
     "njsproj",
+    "nord",
     "ntvs",
+    "oxlint",
+    "unmaximize",
     "vitepress"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "dist-electron/main/index.js",
   "engines": {
-    "node": ">=20.17.0 <20.18.0"
+    "node": ">=20.17.0"
   },
   "scripts": {
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --external:electron --outfile=dist-electron/main/index.js",

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -10,7 +10,11 @@ const currentScrollRatio = ref(0)
 const isInitialized = ref(false)
 
 watch(isModified, (newValue) => {
-  window.electronAPI.changeSaveStatus(!newValue) // 通知主进程保存状态, 修改后(isModified==true) isSaved 为 false
+  // 只有在有内容时才通知主进程保存状态
+  // 如果 markdown 为空且 originalContent 也为空，说明是新建文档，不需要通知
+  if (contentInfo.markdown.value || contentInfo.originalContent.value) {
+    window.electronAPI.changeSaveStatus(!newValue) // 通知主进程保存状态, 修改后(isModified==true) isSaved 为 false
+  }
 }, { immediate: true })
 
 function recordScrollRatio(wrapper: HTMLElement) {
@@ -18,7 +22,8 @@ function recordScrollRatio(wrapper: HTMLElement) {
 }
 
 function initScrollListener() {
-  if (isInitialized.value) return
+  if (isInitialized.value)
+    return
   const milkdownWrapper = document.querySelector('.scrollView.milkdown') as HTMLElement | null
   const codeMirrorWrapper = document.querySelector('.cm-scroller') as HTMLElement | null
   if (milkdownWrapper) {
@@ -45,11 +50,10 @@ export default () => {
     removeScrollListener()
   })
 
-
   return {
     ...contentInfo,
     isModified,
     currentScrollRatio,
-    initScrollListener
+    initScrollListener,
   }
 }

--- a/src/hooks/useFile.ts
+++ b/src/hooks/useFile.ts
@@ -20,16 +20,12 @@ async function onOpen() {
   }
 }
 
-async function onSave(quitAfter: boolean) {
+async function onSave() {
   const saved = await window.electronAPI.saveFile(filePath.value || null, markdown.value)
   if (saved) {
     filePath.value = saved
     originalContent.value = markdown.value
     updateTitle()
-    if (quitAfter) {
-      window.electronAPI.changeSaveStatus(true)
-      window.electronAPI.windowControl('close')
-    }
   }
   return saved
 }

--- a/src/hooks/useSaveConfirmDialog.ts
+++ b/src/hooks/useSaveConfirmDialog.ts
@@ -1,0 +1,45 @@
+import { ref } from 'vue'
+
+export function useSaveConfirmDialog() {
+  const isDialogVisible = ref(false)
+  const resolvePromise = ref<((value: 'save' | 'discard' | 'cancel') => void) | null>(null)
+
+  const showDialog = (): Promise<'save' | 'discard' | 'cancel'> => {
+    return new Promise((resolve) => {
+      isDialogVisible.value = true
+      resolvePromise.value = resolve
+    })
+  }
+
+  const handleSave = () => {
+    isDialogVisible.value = false
+    if (resolvePromise.value) {
+      resolvePromise.value('save')
+      resolvePromise.value = null
+    }
+  }
+
+  const handleDiscard = () => {
+    isDialogVisible.value = false
+    if (resolvePromise.value) {
+      resolvePromise.value('discard')
+      resolvePromise.value = null
+    }
+  }
+
+  const handleCancel = () => {
+    isDialogVisible.value = false
+    if (resolvePromise.value) {
+      resolvePromise.value('cancel')
+      resolvePromise.value = null
+    }
+  }
+
+  return {
+    isDialogVisible,
+    showDialog,
+    handleSave,
+    handleDiscard,
+    handleCancel,
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setTitle: (filePath: string | null) => ipcRenderer.send('set-title', filePath),
   changeSaveStatus: (isSaved: boolean) => ipcRenderer.send('change-save-status', isSaved),
   windowControl: (action: 'minimize' | 'maximize' | 'close') => ipcRenderer.send('window-control', action),
+  closeDiscard: () => ipcRenderer.send('close:discard'),
   onOpenFileAtLaunch: (cb: (payload: { filePath: string, content: string }) => void) => {
     ipcRenderer.once('open-file-at-launch', (_event, payload) => {
       cb(payload)
@@ -17,6 +18,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openExternal: (url: string) => ipcRenderer.send('shell:openExternal', url),
   getFilePathInClipboard: () => ipcRenderer.invoke('clipboard:getFilePath'),
   writeTempImage: (file: File, tempPath: string) => ipcRenderer.invoke('clipboard:writeTempImage', file, tempPath),
-  showMessageBoxSync: (options: Electron.MessageBoxSyncOptions) => ipcRenderer.invoke('dialog:OpenDialog', options),
   platform: process.platform,
 })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2,21 +2,26 @@
 import { MilkdownProvider } from '@milkdown/vue'
 import { nextTick, ref, watch } from 'vue'
 import useContent from '@/hooks/useContent'
+import useFile from '@/hooks/useFile'
 import { isShowOutline } from '@/hooks/useOutline'
+import { useSaveConfirmDialog } from '@/hooks/useSaveConfirmDialog'
 import useSourceCode from '@/hooks/useSourceCode'
 import useTheme from '@/hooks/useTheme'
 import useTitle from '@/hooks/useTitle'
 import MarkdownSourceEditor from './components/MarkdownSourceEditor.vue'
 import MilkdownEditor from './components/MilkdownEditor.vue'
 import Outline from './components/Outline.vue'
+import SaveConfirmDialog from './components/SaveConfirmDialog.vue'
 import StatusBar from './components/StatusBar.vue'
-import Titlebar from './components/Titlebar.vue'
+import TitleBar from './components/TitleBar.vue'
 import emitter from './events'
 
 const { updateTitle } = useTitle()
 const { markdown } = useContent()
 const { themeName } = useTheme()
 const { isShowSource } = useSourceCode()
+const { isDialogVisible, showDialog, handleSave, handleDiscard, handleCancel } = useSaveConfirmDialog()
+const { onSave } = useFile()
 const isShowEditors = ref(true)
 
 watch(markdown, () => {
@@ -28,6 +33,23 @@ watch([themeName, isShowSource], () => {
 emitter.on('file:Change', () => {
   reBuildMilkdown()
 })
+
+// 监听关闭确认事件
+window.electronAPI.on('close:confirm', async () => {
+  const result = await showDialog()
+  if (result === 'save') {
+    await onSave()
+  } else if (result === 'discard') {
+    // 直接关闭应用
+    window.electronAPI.closeDiscard()
+  }
+})
+
+// 监听保存触发事件
+window.electronAPI.on('trigger-save', async () => {
+  await onSave()
+})
+
 function reBuildMilkdown() {
   isShowEditors.value = false
   nextTick(() => {
@@ -37,7 +59,7 @@ function reBuildMilkdown() {
 </script>
 
 <template>
-  <Titlebar />
+  <TitleBar />
   <div v-if="isShowEditors" class="editorArea">
     <Transition name="fade" mode="out-in">
       <div v-show="isShowOutline && !isShowSource" class="outlineBox">
@@ -52,6 +74,12 @@ function reBuildMilkdown() {
     </div>
   </div>
   <StatusBar :content="markdown" />
+  <SaveConfirmDialog
+    :visible="isDialogVisible"
+    @save="handleSave"
+    @discard="handleDiscard"
+    @cancel="handleCancel"
+  />
 </template>
 
 <style scoped lang="less">

--- a/src/renderer/components/SaveConfirmDialog.vue
+++ b/src/renderer/components/SaveConfirmDialog.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+interface Props {
+  visible: boolean
+}
+
+interface Emits {
+  (e: 'save'): void
+  (e: 'discard'): void
+  (e: 'cancel'): void
+}
+
+const { visible } = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+function handleSave() {
+  emit('save')
+}
+
+function handleDiscard() {
+  emit('discard')
+}
+
+function handleCancel() {
+  emit('cancel')
+}
+</script>
+
+<template>
+  <Transition name="dialog-fade" appear>
+    <div v-if="visible" class="dialog-overlay">
+      <div class="dialog-content" @click.stop>
+        <div class="dialog-header">
+          <h3>确认关闭</h3>
+        </div>
+        <div class="dialog-body">
+          <p>当前文档有未保存的修改，请选择操作：</p>
+        </div>
+        <div class="dialog-footer">
+          <button class="btn btn-secondary" @click="handleDiscard">
+            丢弃
+          </button>
+          <div>
+            <button class="btn btn-save" @click="handleSave">
+              保存
+            </button>
+            <button class="btn btn-secondary" @click="handleCancel">
+              取消
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped lang="less">
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: all 0.3s ease;
+}
+
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+
+.dialog-fade-enter-from .dialog-content,
+.dialog-fade-leave-to .dialog-content {
+  transform: translateY(-20px) scale(0.95);
+}
+
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  backdrop-filter: blur(2px);
+}
+
+.dialog-content {
+  background: var(--bg-color, #ffffff);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  min-width: 400px;
+  max-width: 500px;
+  transition: transform 0.3s ease;
+}
+
+.dialog-header {
+  padding: 20px 24px 0;
+
+  h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-color, #333);
+  }
+}
+
+.dialog-body {
+  padding: 16px 24px;
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-secondary, #666);
+    line-height: 1.5;
+  }
+}
+
+.dialog-footer {
+  padding: 0 24px 20px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:active {
+    transform: translateY(0);
+  }
+}
+
+.btn-save {
+  margin-right: 12px;
+  background: linear-gradient(135deg, #74b9ff 0%, #0984e3 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(116, 185, 255, 0.3);
+
+  &:hover {
+    background: linear-gradient(135deg, #6ab0f0 0%, #0873c4 100%);
+    box-shadow: 0 4px 12px rgba(116, 185, 255, 0.4);
+  }
+
+  &:active {
+    background: linear-gradient(135deg, #60a7e6 0%, #0762a5 100%);
+  }
+}
+
+.btn-secondary {
+  background: #f8f9fa;
+  color: #6c757d;
+  border: 1px solid #e9ecef;
+
+  &:hover {
+    background: #e9ecef;
+    color: #495057;
+    border-color: #dee2e6;
+  }
+
+  &:active {
+    background: #dee2e6;
+    color: #343a40;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .dialog-content {
+    --bg-color: #1f1f1f;
+    --text-color: #ffffff;
+    --text-secondary: #a0a0a0;
+  }
+
+  .btn-save {
+    background: linear-gradient(135deg, #74b9ff 0%, #0984e3 100%);
+    color: white;
+    box-shadow: 0 2px 8px rgba(116, 185, 255, 0.3);
+
+    &:hover {
+      background: linear-gradient(135deg, #6ab0f0 0%, #0873c4 100%);
+      box-shadow: 0 4px 12px rgba(116, 185, 255, 0.4);
+    }
+
+    &:active {
+      background: linear-gradient(135deg, #60a7e6 0%, #0762a5 100%);
+    }
+  }
+
+  .btn-secondary {
+    background: #2d3748;
+    color: #a0aec0;
+    border: 1px solid #4a5568;
+
+    &:hover {
+      background: #4a5568;
+      color: #e2e8f0;
+      border-color: #718096;
+    }
+
+    &:active {
+      background: #718096;
+      color: #f7fafc;
+    }
+  }
+}
+</style>

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -23,7 +23,7 @@ window.electronAPI.on('close', () => {
 </script>
 
 <template>
-  <div class="TitlebarBox">
+  <div class="TitleBarBox">
     <template v-if="isWin">
       <MenuDropDown />
       <div class="title" @dblclick="toggleMaximize">
@@ -46,7 +46,7 @@ window.electronAPI.on('close', () => {
 </template>
 
 <style lang="less" scoped>
-.TitlebarBox {
+.TitleBarBox {
   -webkit-app-region: drag;
   /* ✅ 允许拖动窗口 */
   height: 32px;
@@ -55,8 +55,7 @@ window.electronAPI.on('close', () => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 12px;
-  padding-right: 0;
+  padding: 0 0 0 12px;
   user-select: none;
 
   .window-controls {

--- a/src/renderer/events/index.ts
+++ b/src/renderer/events/index.ts
@@ -1,10 +1,14 @@
 import mitt from 'mitt'
 
-interface Events {
+type Events = {
   'file:Change': void // Triggered when a file is changed
   'spellcheck:Update': boolean // Triggered when spellcheck is updated
   'outline:Update': Array<{ text: string, level: number, id: string }> // Triggered when the outline is updated
-}
+  'close:confirm': void // Triggered when need to show close confirmation dialog
+  'close:discard': void // Triggered when user chooses to discard changes
+  'menu-save': boolean // Triggered when user wants to save
+  'trigger-save': boolean // Triggered when main process requests save
+} & Record<string, unknown>
 
 const emitter = mitt<Events>()
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -8,11 +8,11 @@ interface Window {
     on: (channel: string, listener: (...args: any[]) => void) => void
     removeListener: (channel: string, listener: (...args: any[]) => void) => void
     windowControl: (action: 'minimize' | 'maximize' | 'close') => void
+    closeDiscard: () => void
     onOpenFileAtLaunch: (cb: (payload: { filePath: string, content: string }) => void) => void
     openExternal: (url: string) => Promise<void>
     getFilePathInClipboard: () => Promise<string | null>
     writeTempImage: (file: ArrayBufferLike, tempPath: string) => Promise<string>
-    showMessageBoxSync: (options: Electron.MessageBoxSyncOptions) => Promise<Electron.MessageBoxReturnValue>
     platform: NodeJS.Platform
   }
 }


### PR DESCRIPTION
- 新增 SaveConfirmDialog 组件用于关闭前确认
- 在主进程和渲染进程之间添加关闭确认的通信机制
- 优化了保存逻辑,只有在有内容时才通知主进程保存状态
- 重构了 onSave 方法,移除了冗余参数