### PR TITLE
ci: add comment on PR merge workflow

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -1,0 +1,40 @@
+# 当 PR 被合并时，留言欢迎加入共建群
+name: PullRequest Contributor Welcome
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    permissions:
+      issues: write  # for actions-cool/maintain-one-comment to modify or create issue comments
+      pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
+    if: github.event.pull_request.merged == true && github.repository == 'Auto-Plugin/milkup'
+    runs-on: ubuntu-latest
+    steps:
+      - name: get commit count
+        id: get_commit_count
+        run: |
+          PR_AUTHOR=$(echo "${{ github.event.pull_request.user.login }}")
+          RESULT_DATA=$(curl -s "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
+          DATA_LENGTH=$(echo $RESULT_DATA | jq 'if type == "array" then length else 0 end')
+          echo "COUNT=$DATA_LENGTH" >> $GITHUB_OUTPUT
+      - name: Comment on PR
+        if: steps.get_commit_count.outputs.COUNT < 3
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            🎉 Thank you for your contribution! If you have not yet joined our community group, please feel free to join us (when joining, please provide the link to this PR).
+
+            🎉 感谢您的贡献！如果您对此项目非常感兴趣，请扫描下方二维码加入我们（加群时请提供此 PR 链接）。
+
+            <img src="https://github.com/Auto-Plugin/milkup/blob/master/public/qun.jpg?raw=true" width="200" />
+
+            <!-- WELCOME_CONTRIBUTION -->
+          body-include: <!-- WELCOME_CONTRIBUTION -->


### PR DESCRIPTION
Add a GitHub Actions workflow that automatically posts a comment when a PR is successfully merged and closed.