### PR TITLE
Improve uploadImage body type handling

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,25 @@
 
 import autotoast from 'autotoast.js'
 
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result
+      if (typeof result === 'string') {
+        const base64Content = result.includes(',') ? result.split(',')[1] : result
+        resolve(base64Content)
+      } else {
+        reject(new Error('Failed to read file as base64'))
+      }
+    }
+    reader.onerror = () => {
+      reject(reader.error || new Error('Failed to read file as base64'))
+    }
+    reader.readAsDataURL(file)
+  })
+}
+
 // localStorage.setItem('uploadExtraBody', extraBody.value)
 export async function uploadImage(File: File): Promise<string> {
   const url = localStorage.getItem('uploadUrl')
@@ -15,36 +34,76 @@ export async function uploadImage(File: File): Promise<string> {
     autotoast.show('Upload URL is not set', 'error')
     throw new Error('Upload URL is not set')
   }
-  let body: any = {}
-  switch (localStorage.getItem('uploadBodyType')) {
-    case 'multipart/form-data':
-      body = new FormData()
-      body.append(localStorage.getItem('uploadFileField') || 'file', File)
-      break
-    case 'application/json':
-      body = JSON.parse(localStorage.getItem('uploadExtraBody') || '{}')
-      body[localStorage.getItem('uploadFileField') || 'file'] = File
-      break
-    case 'application/x-www-form-urlencoded':
-      body = new URLSearchParams()
-      body.append(localStorage.getItem('uploadFileField') || 'file', File)
-      break
-  }
-  const extraBody = localStorage.getItem('uploadExtraBody')
-  if (extraBody) {
+  const bodyType = localStorage.getItem('uploadBodyType') || 'multipart/form-data'
+  const fileField = localStorage.getItem('uploadFileField') || 'file'
+  const extraBodyRaw = localStorage.getItem('uploadExtraBody')
+  let parsedExtraBody: Record<string, unknown> = {}
+  if (extraBodyRaw) {
     try {
-      const extraFields = JSON.parse(extraBody)
-      for (const key in extraFields) {
-        body[key] = extraFields[key]
-      }
+      parsedExtraBody = JSON.parse(extraBodyRaw)
     } catch (e) {
       autotoast.show('Invalid extra body format', 'error')
     }
   }
+
+  let body: BodyInit | null = null
+  const method = localStorage.getItem('uploadMethod') || 'POST'
+  let headers: Record<string, string> = {}
+  const rawHeaders = localStorage.getItem('uploadHeaders')
+  if (rawHeaders) {
+    try {
+      const parsedHeaders = JSON.parse(rawHeaders)
+      if (parsedHeaders && typeof parsedHeaders === 'object') {
+        headers = parsedHeaders as Record<string, string>
+      }
+    } catch (e) {
+      autotoast.show('Invalid headers JSON format', 'error')
+    }
+  }
+
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'content-type' && headers[key]?.toLowerCase().includes('multipart/form-data')) {
+      delete headers[key]
+    }
+  }
+
+  switch (bodyType) {
+    case 'multipart/form-data': {
+      const formData = new FormData()
+      formData.append(fileField, File)
+      for (const [key, value] of Object.entries(parsedExtraBody)) {
+        formData.append(key, typeof value === 'string' ? value : JSON.stringify(value))
+      }
+      body = formData
+      break
+    }
+    case 'application/json': {
+      const jsonBody: Record<string, unknown> = { ...parsedExtraBody }
+      jsonBody[fileField] = await fileToBase64(File)
+      body = JSON.stringify(jsonBody)
+      const hasContentTypeHeader = Object.keys(headers).some(key => key.toLowerCase() === 'content-type')
+      if (!hasContentTypeHeader) {
+        headers['Content-Type'] = 'application/json'
+      }
+      break
+    }
+    case 'application/x-www-form-urlencoded': {
+      const searchParams = new URLSearchParams()
+      searchParams.append(fileField, File.name)
+      for (const [key, value] of Object.entries(parsedExtraBody)) {
+        searchParams.append(key, typeof value === 'string' ? value : JSON.stringify(value))
+      }
+      autotoast.show('x-www-form-urlencoded does not support file upload. Only file name will be sent.', 'warn')
+      body = searchParams
+      break
+    }
+    default:
+      body = null
+  }
   try {
     const response = await fetch(url, {
-      method: localStorage.getItem('uploadMethod') || 'POST',
-      headers: JSON.parse(localStorage.getItem('uploadHeaders') || '{}'),
+      method,
+      headers,
       body,
     })
     if (!response.ok) {
@@ -64,7 +123,7 @@ export async function uploadImage(File: File): Promise<string> {
     }
     return result || ''
   } catch (error) {
-    autotoast.show(`${error}`, 'error')
+    autotoast.show(error instanceof Error ? error.message : String(error), 'error')
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- add resilient parsing for saved headers and drop conflicting multipart/form-data content-type values
- default to multipart uploads when no body type is configured while keeping JSON uploads base64 encoded with automatic headers
- warn when x-www-form-urlencoded is selected, preserve extra body fields, and surface clearer error messages

## Testing
- npm run lint *(fails: existing lint errors in .github/workflows/pr-contributor-welcome.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c07b29f4832b9b382a11b1accf40