### PR TITLE
fix: bring window to front when opening .md file via Finder on macOS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -172,6 +172,9 @@ function sendFileToRenderer(filePath: string) {
   const sendFile = () => {
     const targetWin = getAvailableWindow();
     if (targetWin) {
+      if (targetWin.isMinimized()) targetWin.restore();
+      if (!targetWin.isVisible()) targetWin.show();
+      targetWin.focus();
       targetWin.webContents.send("open-file-at-launch", {
         filePath: result.filePath,
         content: result.content,


### PR DESCRIPTION
## Summary

Fixed a bug where double-clicking a `.md` file in Finder on macOS loads the file content silently without bringing the milkup window to the foreground. Users have to manually click the app icon in the Dock to see the window.

## Root Cause

The `open-file` event handler (`src/main/index.ts:292`) calls `sendFileToRenderer()` which sends file data to the renderer via IPC, but never calls `focus()` / `show()` / `restore()` on the window. 

In contrast, the `second-instance` handler (line 280) and `activate` handler (line 320) both correctly activate the window before processing.

## Fix

Added 3 lines in `sendFileToRenderer`'s `sendFile` closure to mirror the window activation logic already present in `second-instance`:

```typescript
if (targetWin.isMinimized()) targetWin.restore();
if (!targetWin.isVisible()) targetWin.show();
targetWin.focus();
```

## Affected Scenarios

| Scenario | Before | After |
|----------|--------|-------|
| Cold launch (double-click .md, app not running) | Window may stay behind | ✅ Window comes to front |
| App running, window hidden (red close button on macOS) | Content loaded, window stays hidden | ✅ Window shown + focused |
| App running, window minimized | Content loaded, stays minimized | ✅ Window restored + focused |
| App in foreground, double-click another .md | Works fine | ✅ No change |

## Tested

- macOS arm64 (Apple Silicon) with macOS 26 
- Built and installed locally, verified fix resolves the issue