### PR TITLE
fix: 修复打开 WSL 文件时主进程因 EISDIR 崩溃 (#172)

### DIFF
--- a/src/main/ipcBridge.ts
+++ b/src/main/ipcBridge.ts
@@ -1620,6 +1620,13 @@ export function registerGlobalIpcHandlers() {
           }
         }
       });
+
+      // chokidar 在监听/遍历出错时会 emit "error"；若无监听器，EventEmitter 会把错误
+      // 抛成主进程 uncaughtException（例如 \\wsl.localhost\ 下对 Linux 软链接 lstat 返回
+      // EISDIR）。这里吞掉并记录，避免整个应用崩溃。
+      watcher.on("error", (error) => {
+        console.warn("[file:watch] watcher error:", error);
+      });
     }
 
     // 新增的文件 - 添加到 watcher
@@ -1671,6 +1678,12 @@ export function registerGlobalIpcHandlers() {
     directoryWatcher.on("unlink", notifyChanged);
     directoryWatcher.on("addDir", notifyChanged);
     directoryWatcher.on("unlinkDir", notifyChanged);
+    // chokidar 递归遍历目录时若对某个条目 lstat 失败会 emit "error"。典型场景：监听
+    // \\wsl.localhost\ (WSL/9P) 下的目录，对 Linux 软链接（如 *.so.0）lstat 返回 EISDIR。
+    // 没有该监听器时错误会冒泡为主进程 uncaughtException 导致崩溃，这里吞掉并记录。
+    directoryWatcher.on("error", (error) => {
+      console.warn("[workspace:watchDirectory] watcher error:", error);
+    });
   });
 
   // 停止监听目录

--- a/src/renderer/utils/workspacePath.ts
+++ b/src/renderer/utils/workspacePath.ts
@@ -10,8 +10,14 @@ export function isAbsoluteLocalPath(pathValue: string): boolean {
   return pathValue.startsWith("/");
 }
 
+// 注意：本模块在渲染进程执行（nodeIntegration:false），渲染进程里 process.platform 不可用，
+// platform.ts 的 isWindows 会恒为 false。因此这里【不能】用 isWindows 做前置短路，否则本防护
+// 会永远失效——曾导致打开 WSL 文件时仍自动加载工作区，进而对 \\wsl.localhost\ 下的 Linux 软链接
+// （如 librockchip_mpp.so.0）lstat 触发 EISDIR，使主进程未捕获异常崩溃。
+// UNC 路径（\\wsl.localhost\、\\wsl$\、\\server\share）本身是 Windows 专有写法，不会出现在其他
+// 平台的合法路径里，无需平台判断即可安全识别为远程路径。
 export function isRemoteWorkspacePath(pathValue: string): boolean {
-  if (!pathValue || !isWindows) return false;
+  if (!pathValue) return false;
 
   return /^\\\\wsl(?:\$|\.localhost)\\/i.test(pathValue) || /^\\\\(?![?.]\\)/.test(pathValue);
 }


### PR DESCRIPTION
## 问题

修复 #172：在 Windows 上打开 WSL(`\\wsl.localhost\`)里的文件时，文件区(Explorer)卡死并不停弹出：

> A JavaScript error occurred in the main process
> Uncaught Exception: Error: EISDIR: illegal operation on a directory, lstat '...'

## 根因

打开文件时，应用会自动把文件所在目录作为工作区，并用 chokidar 递归监听(`workspace:watchDirectory`，`depth:10`)。chokidar 遍历到目录里的 Linux 软链接(例如 `librockchip_mpp.so.0` 这种 `.so` 版本软链接)时会对它 `lstat`。

而 Windows/Node 对经 9P 重定向器暴露的 WSL 软链接做 `lstat` 会返回 `EISDIR`——底层其实是 9P 不支持读取该软链接的 reparse 数据，返回 `Incorrect function`(`ERROR_INVALID_FUNCTION`)，被 libuv 映射成了 `EISDIR`，所以错误信息里的 "directory" 是个误导(它跟目录无关)。

这个错误没有任何地方接住：chokidar emit 的 `error` 事件没有监听器，主进程也没有 `uncaughtException` 处理，于是冒泡成未捕获异常并反复弹框。

另外，项目其实已经有一道针对 WSL/远程路径的防护 `shouldAutoLoadWorkspace`，但它依赖 `isWindows`，而 `isWindows` 由 `getPlatform()` 读 `process.platform` 得出——这段代码运行在渲染进程(`nodeIntegration:false`)，那里没有 Node 的 `process`，`isWindows` 恒为 `false`，导致这道防护从未真正生效。

## 修复(双保险)

- **`workspacePath.ts`**：`isRemoteWorkspacePath` 去掉 `!isWindows` 前置短路。UNC 路径(`\\wsl.localhost\`、`\\wsl$\`、`\\server\share`)本身是 Windows 专有写法，不会出现在其他平台的合法路径里，无需平台判断即可安全识别。去掉短路后防护真正生效，从源头避免对 WSL 目录自动加载工作区与递归监听。
- **`ipcBridge.ts`**：给 file watcher 与 directoryWatcher 各补一个 `.on("error")`。chokidar 出错时会 emit `error`，没有监听器就会冒泡成主进程 uncaughtException；补上后任何 watcher 错误只记录、不再使应用崩溃，对所有文件系统(不止 WSL)都更健壮。

## 影响 / 后续

本次修复保证不再崩溃，文件可正常打开、编辑、保存。代价是 **WSL 文件暂时不会自动加载左侧文件树**(防护把它跳过了)。

后续会做**第二层改进**，让 WSL 文件也能正常显示文件树——思路是改用 `readdir`(在 WSL 上正常，且能识别软链接而不对其 `lstat`)配合轮询刷新，绕开会对每个软链接 `lstat` 的 chokidar。该改进会作为后续单独的 PR 提交。
