### PR TITLE
feat: WSL/远程文件树与外部变更监听(第二层，基于 #236)

### DIFF
--- a/docs/spec-wsl-file-watching-layer2.md
+++ b/docs/spec-wsl-file-watching-layer2.md
@@ -1,0 +1,167 @@
+# 规约：WSL/远程文件监听第二层（轮询路线）
+
+状态：草案 v2（已合入 2026-06-04 code review），待实施
+前置条件：等第一层 PR #236 合入/有结论后再动手 + 完成 §0 前置实测
+关联：上游 issue #172、PR #236（第一层修复）
+
+---
+
+## 0. 前置实测（动手前必须先做，否则方案不成立）
+
+第一层之所以"跳过 WSL 工作区加载"，是因为加载会崩 EISDIR。第二层要撤销跳过，**必须先用实测证明完整建树路径全程不踩 EISDIR**，否则等于重开第一层堵住的崩溃口。
+
+- [前置实测 A] **完整建树路径无 EISDIR**：在一个含 `普通文件 / 子目录 / 指向文件的 symlink / 指向目录的 symlink / dangling symlink / >100 文件的大目录 / >10 层深目录` 的真实 WSL 目录上，跑 `scanDirectory` 等价递归（readdir withFileTypes + 对 dir 递归 + 对 file stat），断言：全程 0 次 EISDIR / 0 uncaughtException / 0 unhandledRejection。重点验证"递归进 symlink 指向的目录"和"对 dirent 做 stat 而非 lstat"两条路径。
+- [前置实测 B] **fs.watchFile 在 9P 的可靠性边界**：已初步实测可检测 `echo >>` 追加（mtime 推进）。补测：原子替换（写临时文件 + rename 覆盖、`cp -p` 保留 mtime、`mv` 保留时间戳）、删除后重建、9P 同秒内多次写。记录哪些能检测、哪些漏报——漏报项必须由 §4.4 的 size/focus 兜底覆盖。
+
+两项任一失败，则对应设计分支需改方案或缩小范围，不得按本规约直接实现。
+
+## 1. 背景
+
+第一层（PR #236）已止血：打开 WSL 文件不再因 `EISDIR` 崩溃。代价是 WSL 路径被 `shouldAutoLoadWorkspace` 跳过——WSL 文件没有左侧文件树，也不提示外部变更。
+
+第二层目标：让 WSL/远程文件也能 (1) 显示左侧文件树；(2) 外部进程修改文件时弹"重新加载"提示。
+
+## 2. 实测依据（决定技术选型）
+
+在 `\\wsl.localhost\` 路径下，从 **WSL 内部进程**修改文件，实测结果：
+
+| 方式                                   | 结果        | 用途             |
+|----------------------------------------|-------------|------------------|
+| `fs.watch`（事件，chokidar 底层）      | 启动即 EISDIR | 不可用           |
+| `fs.watchFile`（Node 内置轮询）        | 检测到追加写 | 监听已打开文件（边界见 §0-B） |
+| 轮询 `fs.statSync().mtimeMs`           | 检测到追加写 | 文件树快照源     |
+| `fs.readdir({withFileTypes:true})`     | 正常        | 构建文件树       |
+
+结论：**事件式监听在 WSL 9P 上不支持；轮询路径可行。**
+
+关键澄清（评审修正）：
+- `readdir({withFileTypes:true})` 本身不对 symlink 单独 lstat，故 readdir 不踩 EISDIR；但**这不等于 symlink 会进文件树**——分类逻辑见 §4.1（必须显式加 `isSymbolicLink()` 分支，否则 symlink 被丢弃）。
+- "轮询用普通文件 stat 安全"只覆盖单文件场景。文件树轮询/建树处理对象含目录与 symlink，安全性由 §0-A 实测背书，不由该单点结论背书。
+- CudaText(FPC) 走轮询仅作旁证，不构成 Node `fs.watchFile`/`setInterval` 在 Electron 主进程 + 9P 下可靠的证据；可靠性以 §0-B 实测为准。
+
+## 3. 目标、非目标与范围边界
+
+目标：WSL/远程 = 文件树(静态) + 文件树自动刷新(轮询) + 已打开文件外部变更提示(轮询 + size/focus 兜底)；本地保持 chokidar 实时，不退化。
+
+非目标：不追求 WSL 实时(轮询秒级延迟可接受)；不改本地事件监听逻辑。
+
+范围边界（评审修正，明确写死）：
+- **仅 `\\wsl.localhost\` / `\\wsl$\` 走轮询。** 普通 SMB(`\\server\share`) 第二层**沿用 chokidar**（SMB 上 fs.watch 通常可用），不一刀切降级；是否对 SMB 也轮询，待单独实测后另行决定（见 §8 defer）。
+- **本地工作区内嵌指向 WSL 的 junction/symlink** 是已知盲区：分流按顶层 `dirPath` 判定，无法拦截本地树内的远程子路径，chokidar 递归到它仍会 EISDIR。该场景**只能靠第一层 error handler 吞错兜底**（不崩，但该子树不工作），第二层不解决，文档化为已知局限。
+- **已知漏判路径**（见 §4.0）：`Z:\` 之类把 WSL 映射成盘符的情况，第二层不识别为远程；文档化告知用户用 UNC 形式打开。
+
+## 4. 设计：按路径分流
+
+核心：仅 WSL 走轮询，其余（本地 + SMB）走 chokidar。
+
+### 4.0 路径判定（评审修正）
+
+判定函数放在 **main 进程**（有真实 `process.platform`），输入先做前缀归一化再匹配：
+
+1. 归一化：把 `\\?\UNC\server\share\...` 还原为 `\\server\share\...`；`\\?\C:\...` 还原为 `C:\...`（否则 `\\?\UNC\wsl.localhost\` 会被旧正则的 `(?![?.]\\)` 误判为本地，重开 EISDIR）。
+2. 仅当归一化后匹配 `^\\\\wsl(?:\$|\.localhost)\\` 时判为"WSL 远程，走轮询"。
+3. 其余（本地盘符、SMB UNC、`Z:\` 映射）一律走 chokidar。
+
+已知漏判（文档化，不在本层解决）：WSL 被 `net use` 映射成 `Z:\` 时归一化后是盘符形式，判为本地→chokidar 递归会 EISDIR→由 error handler 兜底。提示用户以 `\\wsl.localhost\` 形式打开。
+
+### 4.1 main：`workspace:watchDirectory`（远程分支）
+
+- 本地/SMB：现状不变（chokidar，`depth:10`，已有 300ms debounce）。
+- WSL 远程：不创建 chokidar，改用 `setInterval` 定时重扫。要求：
+  - **per-dirPath 维护 interval 句柄**（不可单例，否则多窗口/多工作区互相覆盖泄漏）。入口先清掉本 dirPath 旧 interval 再建（对称于 chokidar 分支的 `close()` 自清），不只依赖 `unwatchDirectory`。
+  - **in-flight guard**：上一轮 `scanDirectory` 未完成则跳过本轮 tick（9P readdir 可能 >间隔）。`clearInterval` 后到达的迟到 readdir 结果**丢弃不广播**（用一个 generation/epoch 标记，回调完成时校验仍是当前代）。
+  - **快照对比用 `path + mtimeMs + size` 集合**（评审修正：仅 mtime 漏掉原子替换/保留 mtime/重命名互换；加 size 显著降低漏报，仍非 100%，但配合内容读取后比对可接受）。差异即调 §4.1-broadcast。
+  - **后端不可达判别**：`existsSync(dirPath)` 为 false 时，区分"WSL 整体不可达(shutdown/断开)"与"目录真被删"——不可达时**保持上次快照、不广播全删**（避免树被清空又重建）。判别可用：上次快照非空且本次 readdir 抛 ENOENT/超时 → 视为不可达，跳过本轮。
+  - **截断一致性**：复用 `scanDirectory` 的 `MAX_FILES_PER_DIR(100)` / `MAX_DEPTH(10)` 截断意味着被砍部分的变更检测不到。需在文档/UI 标注"大目录/深层不保证刷新"，或为远程轮询单独放宽/分页（取舍见 §5），避免 §6 验收对大目录假成立。
+- **广播去抖**：远程分支也要 300ms debounce（对齐本地），且 `directory-changed` 触发的 renderer `refreshWorkSpace` 需与下一轮 interval **互斥**（refresh 进行中不叠加新 refresh）。
+
+### 4.2 main：`file:watch`（远程分支）
+
+- 本地/SMB 文件：现状不变（chokidar `watcher.add`）。
+- WSL 远程文件：`fs.watchFile(file,{interval},cb)`，要求：
+  - **partition 规则**：对收到的混合 `newFilePaths`，按 §4.0 判定逐个分到 chokidar 集合 / 远程 watchFile 集合，保证不重叠、无遗漏；一个文件路径规范化后归属改变时，先从旧集合移除再加新集合。
+  - **引用计数**（评审修正）：远程文件用 `Map<path, refCount>` 而非裸 Set。多窗口/多 tab 打开同一文件 refCount++；关闭 refCount--，**归零才 `unwatchFile`**（否则关一个 tab 误伤仍开着的另一窗口）。注：本地 chokidar 路径继承现有全局单例同类竞态，本规约不回头修，但远程新代码不得复制该缺陷。
+  - **退出清理**：`app.on('before-quit')` 遍历远程 Map 全部 `unwatchFile`（StatWatcher 是 ref 句柄，残留会阻止进程退出）。
+  - **mtime=0（文件消失）处理**：cb 收到 `curr.mtimeMs===0` 表示文件不存在——不要当普通变更广播给 renderer 去读（会读失败）；改为发"文件已删除"语义或静默,等重建后(mtime>0)再正常报。原子替换(unlink+新 inode)后能否继续跟踪由 §0-B 实测确认。
+  - **size 兜底**：cb 里同时比对 `size`，覆盖 mtime 不变但内容变的情况（与 §4.1 快照同理）。
+
+### 4.3 renderer：`getWorkSpace`
+
+- 撤销第一层对 WSL 的"完全跳过"：WSL 也调 `getDirectoryFiles` 建树（建树安全性由 §0-A 背书）。下游监听由 main 按 §4.0 自动分流。
+- **`scanDirectory` 分类修正**（评审修正，核心）：现 `isDirectory()/isFile()` 二分会丢弃 symlink（两者皆 false）。必须加 `isSymbolicLink()` 分支：symlink 进树并标记类型；其 mtime 进快照（否则 symlink 出现/消失/重指向不刷新）。是否解引用递归由策略决定（默认不解引用，避免环 + 避免对 symlink 指向目录的额外 stat 风险）。
+- **空树与一次性锁**：远程首扫慢/超时/全 symlink 时 `getDirectoryFiles` 可能返回 `[]`，现逻辑 `!result.length` 在置 `isLoadWorkSpace` 前早返回→锁不置位→tabs 变化反复整树重扫慢 9P。修正：远程返回空时也置位（或加"远程已尝试加载"独立标志），避免反复重扫；远程的周期刷新由 §4.1 interval 负责，不依赖 tabs watch 重触发。
+
+### 4.4 已打开文件的 mtime 兜底（一期交付，非二期）
+
+评审修正：focus 兜底是 watchFile 漏报（保留 mtime 类修改）的唯一补救，**下放到一期**：
+- 窗口 `focus` 时，对当前打开的远程文件主动 `stat` 一次，比对 `mtime+size`，变化即触发重载提示。
+- 低频 `fs.watchFile` 作为后台兜底。两者结合覆盖"用户切回窗口"和"窗口在前台时被改"两种时机。
+
+## 5. 关键参数（评审修正：阈值与延迟解耦）
+
+| 项                         | 建议值      | 说明                                   |
+|----------------------------|-------------|----------------------------------------|
+| 远程文件树轮询间隔         | 4000ms      | 实际刷新延迟 ≈ 间隔 + scan耗时,非"间隔=延迟" |
+| 远程单文件 mtime 轮询间隔  | 1500ms      | 检测延迟最坏 ≈ 间隔 + 读文件 + IPC      |
+| 广播 debounce             | 300ms       | 对齐本地 chokidar                       |
+| in-flight guard           | 启用        | scan 未完跳过本轮 tick                  |
+| 大目录降级阈值            | 待 §0-A 实测定 | 超阈值放宽间隔/分页/标注不保证刷新     |
+
+参数须由 §0 实测的 9P stat/readdir 实耗校准；下表 §6 阈值由这些间隔 **加处理余量**推出，不得反向用阈值倒推间隔（消除循环论证）。
+
+## 6. 验收标准（评审修正）
+
+1. **本地不退化（可量化）**：本地工作区文件树构建时间、外部变更提示延迟，与改动前基线相比差异 ≤ 基线的 10%（同机同目录对比，各 5 次取中位数）。SMB 工作区同样保持 chokidar 实时（变更后 < 1s 提示）。
+2. **WSL 文件**：
+   - 出现文件树，且**含 symlink 项**（验证 §4.3 分类修正）；
+   - WSL 内 `echo x >> file` 后，检测延迟 ≤ (单文件间隔 1500ms + 处理余量 1000ms) = **2.5s**；
+   - 原子替换（保留 mtime）后，由 size 兜底或 focus 兜底检测到（验证 §4.4）；
+   - 新建/删除文件后 ≤ (树间隔 4000ms + 余量 1500ms) = **5.5s**（目录 ≤100 项、≤10 层；超规模按降级策略另定，不在本条）；
+   - 全程无 EISDIR / uncaughtException / unhandledRejection。
+3. **不可达不误清**：轮询中 `wsl --shutdown`，文件树**不被清空**；WSL 重启后恢复（验证 §4.1 不可达判别）。
+4. **多窗口引用计数**：两窗口打开同一 WSL 文件，关其一，另一窗口仍能收到该文件外部变更（验证 §4.2 refCount）。
+5. **无泄漏**：反复开关远程工作区/文件 N 次后，per-dir interval 句柄数、远程 watchFile Map 大小回到基线；`before-quit` 后进程能正常退出（验证句柄已清）。
+6. **混合工作区**：同窗口同时打开本地与 WSL 文件，两者各自的变更提示都工作，无双广播/漏监听（验证 §4.2 partition）。
+
+## 7. 风险与权衡
+
+- 9P readdir/stat 慢：间隔不能太短；大目录需降级策略（§4.1/§5）。
+- 轮询 + size 仍非 100%（同 mtime 同 size 内容变罕见但可能）：由读取后内容比对 / focus 兜底进一步覆盖；可接受。
+- 本地树内嵌 WSL symlink、`Z:\` 映射：已知盲区，error handler 兜底 + 文档告知（§3/§4.0）。
+
+## 8. 与第一层的关系 + 暂缓项
+
+- 第一层（PR #236）：止血。error handler 兜底 + WSL 跳过加载。**保留 error handler**（防御纵深；也是 §3 已知盲区的兜底）。
+- 第二层（本规约）：恢复功能。撤销"跳过加载"、按路径分流到轮询。作为**独立后续 PR**，commit 引用本规约。
+
+暂缓（defer，#236 合入后再定）：
+- **SMB 是否也轮询**：第二层暂对 SMB 沿用 chokidar；待 SMB 上 fs.watch 可靠性单独实测后决定。
+- **对 #236 接口的契约假设 + 过渡态**：第二层 §4.3 撤销跳过的落点依赖 #236 的实现形态；半启用态（有树无提示/有提示树旧）待 #236 合入后据实际接口细化。
+
+---
+
+## 评审 findings（code review 2026-06-04，Blind Hunter + Edge Case Hunter）
+
+> v2 已将 13 条 patch 全部并入正文（下方勾选标注落点）。2 条 defer 见 §8。
+
+### 已解决（并入正文）
+- [x] [Patch] mtime 唯一真相 → §0-B 实测边界 + §4.1 快照加 size + §4.2 size 兜底 + §4.4 focus 兜底提到一期
+- [x] [Patch] 判定漏判重开 EISDIR → §4.0 前缀归一化 + §3/§4.0 文档化 Z:\ 与本地内嵌 symlink 盲区 + error handler 兜底
+- [x] [Patch] symlink 被分类丢弃 → §4.3 scanDirectory 加 isSymbolicLink() 分支 + §6.2 验收"树含 symlink 项"
+- [x] [Patch] 撤销跳过 EISDIR 证据不足 → §0-A 前置实测（完整建树路径无 EISDIR）
+- [x] [Patch] 定时器生命周期三洞 → §4.1 per-dirPath interval + 入口自清 + in-flight guard + epoch 丢弃迟到结果
+- [x] [Patch] fs.watchFile 泄漏与误伤 → §4.2 refCount + before-quit 清理
+- [x] [Patch] 验收时序不自洽 → §5 阈值=间隔+余量(禁倒推) + §6.2 显式换算
+- [x] [Patch] WSL 不可达误清空树 → §4.1 不可达判别(不广播全删) + §6.3 验收
+- [x] [Patch] 目录截断漏变更 → §4.1 截断一致性说明 + §5 大目录降级阈值 + §6.2 规模限定
+- [x] [Patch] 广播无防抖+refresh 无护栏 → §4.1 远程 300ms debounce + refresh 互斥
+- [x] [Patch] 混合列表 partition → §4.2 partition 规则 + §6.6 验收
+- [x] [Patch] isLoadWorkSpace 锁 vs 远程空树 → §4.3 空树也置位/独立标志 + 远程刷新归 interval
+- [x] [Patch] 无退化无定义 → §6.1 量化(≤基线 10%，5 次中位数)
+
+### 暂缓（defer，见 §8）
+- [x] [Defer] SMB 一刀切降级无实测 → §3 改为 SMB 沿用 chokidar；是否轮询待 SMB 实测
+- [x] [Defer] 前置绑死 #236 + 过渡态 → §8 暂缓项，#236 合入后细化
+
+### 已驳回（dismiss，1 条）
+- CudaText 类比谬误：已有独立 Node `fs.watchFile` 实测覆盖，CudaText 仅旁证，措辞问题非缺陷。

--- a/docs/spec-wsl-file-watching-layer2.md
+++ b/docs/spec-wsl-file-watching-layer2.md
@@ -1,8 +1,8 @@
 # 规约：WSL/远程文件监听第二层（轮询路线）
 
-状态：草案 v2（已合入 2026-06-04 code review），待实施
-前置条件：等第一层 PR #236 合入/有结论后再动手 + 完成 §0 前置实测
-关联：上游 issue #172、PR #236（第一层修复）
+状态：草案 v3（§0 前置实测 2026-06-06 已完成，两项 PASS；symlink 分支按实测缩范围），可实施
+前置条件：~~等第一层 PR #236 合入/有结论后再动手~~（见 §8：第二层堆在 #236 之上的独立后续 PR，本地实现不再等 #236）+ ~~完成 §0 前置实测~~（已完成，结果见 §0）
+关联：上游 issue #172、PR #236（第一层修复）；§0 实测脚本与原始输出见本仓提交说明
 
 ---
 
@@ -10,10 +10,25 @@
 
 第一层之所以"跳过 WSL 工作区加载"，是因为加载会崩 EISDIR。第二层要撤销跳过，**必须先用实测证明完整建树路径全程不踩 EISDIR**，否则等于重开第一层堵住的崩溃口。
 
-- [前置实测 A] **完整建树路径无 EISDIR**：在一个含 `普通文件 / 子目录 / 指向文件的 symlink / 指向目录的 symlink / dangling symlink / >100 文件的大目录 / >10 层深目录` 的真实 WSL 目录上，跑 `scanDirectory` 等价递归（readdir withFileTypes + 对 dir 递归 + 对 file stat），断言：全程 0 次 EISDIR / 0 uncaughtException / 0 unhandledRejection。重点验证"递归进 symlink 指向的目录"和"对 dirent 做 stat 而非 lstat"两条路径。
-- [前置实测 B] **fs.watchFile 在 9P 的可靠性边界**：已初步实测可检测 `echo >>` 追加（mtime 推进）。补测：原子替换（写临时文件 + rename 覆盖、`cp -p` 保留 mtime、`mv` 保留时间戳）、删除后重建、9P 同秒内多次写。记录哪些能检测、哪些漏报——漏报项必须由 §4.4 的 size/focus 兜底覆盖。
+- [x] **前置实测 A — 完整建树路径无 EISDIR**：在一个含 `普通文件 / 子目录 / 指向文件的 symlink / 指向目录的 symlink / dangling symlink / .so.0 链 / >100 文件的大目录 / >10 层深目录` 的真实 WSL 目录上，跑生产 `scanDirectory` 逐字复刻（readdir withFileTypes + 对 dir 递归 + 对 file stat），断言：全程 0 次 EISDIR / 0 uncaughtException / 0 unhandledRejection。
+- [x] **前置实测 B — fs.watchFile 在 9P 的可靠性边界**：`fs.watchFile(interval)` 监听 `\\wsl.localhost\` 文件，逐项验证 追加 / 原子替换(mv) / 同 mtime 仅改 size / 删除 / 删后重建 / 同秒多写 能否被检测。
 
-两项任一失败，则对应设计分支需改方案或缩小范围，不得按本规约直接实现。
+### 实测结果（2026-06-06，Debian11 / Node v22 / Windows host）
+
+**A — PASS（建树安全），但 symlink 子目标触发缩范围。** 生产 `scanDirectory` 在上述 WSL 树上建出 115 节点，0 吞错 / 0 EISDIR / 0 uncaught。关键数据：
+
+| 对 WSL symlink 的操作（Windows 侧） | 结果 |
+|----------------------------------------|--------|
+| `lstat`                                | EISDIR（原崩溃面，4/4 复现，对照成立）|
+| `stat`（跟随）                         | ENOENT（**不是 EISDIR**；指向真实存在目标也 ENOENT）|
+| `readlink`                             | EISDIR |
+| `readFile`（跟随）                     | ENOENT |
+
+结论：建树之所以安全，是因为 `readdir` 用 d_type 分类（不 stat），symlink 的 Dirent `isDirectory()/isFile()` 皆 false 被天然丢弃，真实 dir/file 的 `stat` 正常。**新发现：WSL symlink 从 Windows 侧完全读不透**（与相对/绝对、指向文件/目录均无关）—— 见 §4.3 据此修订后的 symlink 设计。
+
+**B — PASS（全绿）。** 7 项修改全部被 `fs.watchFile` 检测到：追加 / 原子替换(新 inode) / **同 mtime 仅改 size**（`prev{mtime=T,size=6}`→`curr{mtime=T,size=25}` 仍触发，证明 9P 上比较含 size）/ 删除（回调 `mtimeMs=0`）/ 删后重建（跟踪跨 inode 存活）/ 同秒两次写（合并为终态）。唯一未覆盖：同 mtime + 同 size 改内容（spec §7 已认定罕见、仅内容哈希可抓，可接受）。
+
+判定：A、B 两项 §0 PASS → §4.1/§4.2/§4.4 设计成立；§4.3 symlink 分支按本结果缩范围（下方修订）。原"任一失败则改方案或缩小范围"已落实于 §4.3。
 
 ## 1. 背景
 
@@ -38,6 +53,7 @@
 - `readdir({withFileTypes:true})` 本身不对 symlink 单独 lstat，故 readdir 不踩 EISDIR；但**这不等于 symlink 会进文件树**——分类逻辑见 §4.1（必须显式加 `isSymbolicLink()` 分支，否则 symlink 被丢弃）。
 - "轮询用普通文件 stat 安全"只覆盖单文件场景。文件树轮询/建树处理对象含目录与 symlink，安全性由 §0-A 实测背书，不由该单点结论背书。
 - CudaText(FPC) 走轮询仅作旁证，不构成 Node `fs.watchFile`/`setInterval` 在 Electron 主进程 + 9P 下可靠的证据；可靠性以 §0-B 实测为准。
+- **（§0-A 实测补充）WSL symlink 从 Windows 侧完全读不透**：`lstat`/`readlink` 返回 EISDIR，`stat`(跟随)/`readFile`(跟随) 返回 ENOENT（即便目标真实存在）。只有 `readdir` 的 d_type 能识别"它是个 symlink"。这是 §4.3 symlink 分支缩范围的直接依据。
 
 ## 3. 目标、非目标与范围边界
 
@@ -88,7 +104,10 @@
 ### 4.3 renderer：`getWorkSpace`
 
 - 撤销第一层对 WSL 的"完全跳过"：WSL 也调 `getDirectoryFiles` 建树（建树安全性由 §0-A 背书）。下游监听由 main 按 §4.0 自动分流。
-- **`scanDirectory` 分类修正**（评审修正，核心）：现 `isDirectory()/isFile()` 二分会丢弃 symlink（两者皆 false）。必须加 `isSymbolicLink()` 分支：symlink 进树并标记类型；其 mtime 进快照（否则 symlink 出现/消失/重指向不刷新）。是否解引用递归由策略决定（默认不解引用，避免环 + 避免对 symlink 指向目录的额外 stat 风险）。
+- **`scanDirectory` 分类修正**（评审修正，核心；**已按 §0-A 实测缩范围**）：现 `isDirectory()/isFile()` 二分会丢弃 symlink（两者皆 false）。处理按路径来源分流：
+  - **本地 / SMB**：加 `isSymbolicLink()` 分支——symlink 可正常 `lstat`/`stat`，进树并标记类型，mtime 进快照；默认不解引用递归（避免环 + 避免对 symlink 指向目录的额外 stat 风险）。
+  - **WSL 远程（§0-A 实测发现）**：symlink 从 Windows 侧完全读不透（`lstat`/`readlink`→EISDIR，`stat`/`readFile`→ENOENT），既拿不到 mtime/size，也无法解引用，更无法点开（点开 symlink 指向的 .md 会 ENOENT）。因此 WSL 分支**默认不把 symlink 放入文件树**（维持第一层 drop 行为，避免"死节点/点开报错"）。其副作用：symlink 的出现/消失可由 readdir 列表 diff 感知，但**重指向不可知、symlink 目标内容不可读**——文档化为已知局限，不在本层解决。
+  - 说明：WSL 下"不解引用"不是策略选择而是平台强制（`stat` 直接 ENOENT）。若后续要在 WSL 树显示 symlink，只能呈现为不可展开/不可打开的 inert 节点 + 明确标记，属独立增强（见 §8 defer）。
 - **空树与一次性锁**：远程首扫慢/超时/全 symlink 时 `getDirectoryFiles` 可能返回 `[]`，现逻辑 `!result.length` 在置 `isLoadWorkSpace` 前早返回→锁不置位→tabs 变化反复整树重扫慢 9P。修正：远程返回空时也置位（或加"远程已尝试加载"独立标志），避免反复重扫；远程的周期刷新由 §4.1 interval 负责，不依赖 tabs watch 重触发。
 
 ### 4.4 已打开文件的 mtime 兜底（一期交付，非二期）
@@ -113,7 +132,7 @@
 
 1. **本地不退化（可量化）**：本地工作区文件树构建时间、外部变更提示延迟，与改动前基线相比差异 ≤ 基线的 10%（同机同目录对比，各 5 次取中位数）。SMB 工作区同样保持 chokidar 实时（变更后 < 1s 提示）。
 2. **WSL 文件**：
-   - 出现文件树，且**含 symlink 项**（验证 §4.3 分类修正）；
+   - 出现文件树（普通文件 + 子目录正常显示）；**WSL 下不含 symlink 项是预期行为**（§0-A：symlink 读不透，按 §4.3 在 WSL 分支丢弃）。symlink 进树 + 标记类型的验收改到 **local/SMB**（symlink 可 stat）；
    - WSL 内 `echo x >> file` 后，检测延迟 ≤ (单文件间隔 1500ms + 处理余量 1000ms) = **2.5s**；
    - 原子替换（保留 mtime）后，由 size 兜底或 focus 兜底检测到（验证 §4.4）；
    - 新建/删除文件后 ≤ (树间隔 4000ms + 余量 1500ms) = **5.5s**（目录 ≤100 项、≤10 层；超规模按降级策略另定，不在本条）；
@@ -135,6 +154,7 @@
 - 第二层（本规约）：恢复功能。撤销"跳过加载"、按路径分流到轮询。作为**独立后续 PR**，commit 引用本规约。
 
 暂缓（defer，#236 合入后再定）：
+- **WSL symlink 在树内的 inert 显示**：§0-A 实测 symlink 读不透，本层在 WSL 分支直接丢弃。若要在 WSL 树呈现 symlink（不可展开/不可打开的 inert 节点 + 标记），属独立增强，暂缓。
 - **SMB 是否也轮询**：第二层暂对 SMB 沿用 chokidar；待 SMB 上 fs.watch 可靠性单独实测后决定。
 - **对 #236 接口的契约假设 + 过渡态**：第二层 §4.3 撤销跳过的落点依赖 #236 的实现形态；半启用态（有树无提示/有提示树旧）待 #236 合入后据实际接口细化。
 
@@ -148,6 +168,7 @@
 - [x] [Patch] mtime 唯一真相 → §0-B 实测边界 + §4.1 快照加 size + §4.2 size 兜底 + §4.4 focus 兜底提到一期
 - [x] [Patch] 判定漏判重开 EISDIR → §4.0 前缀归一化 + §3/§4.0 文档化 Z:\ 与本地内嵌 symlink 盲区 + error handler 兜底
 - [x] [Patch] symlink 被分类丢弃 → §4.3 scanDirectory 加 isSymbolicLink() 分支 + §6.2 验收"树含 symlink 项"
+  - **（§0-A 实测修订）** WSL symlink 读不透（lstat/readlink=EISDIR，stat/readFile=ENOENT）：isSymbolicLink() 分支只对 local/SMB 有效；WSL 分支按缩范围继续丢弃 symlink，"树含 symlink 项"验收移到 local/SMB。inert 显示移入 §8 defer。
 - [x] [Patch] 撤销跳过 EISDIR 证据不足 → §0-A 前置实测（完整建树路径无 EISDIR）
 - [x] [Patch] 定时器生命周期三洞 → §4.1 per-dirPath interval + 入口自清 + in-flight guard + epoch 丢弃迟到结果
 - [x] [Patch] fs.watchFile 泄漏与误伤 → §4.2 refCount + before-quit 清理

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dist:win-x64": "pnpm run generate-icons && pnpm run build && electron-builder --win --x64",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxlint --fix . && oxfmt .",
+    "test": "node --experimental-strip-types --test \"test/**/*.test.mjs\"",
     "prepare": "simple-git-hooks",
     "preinstall": "npx only-allow pnpm",
     "release": "genereleaselog",

--- a/src/main/ipcBridge.ts
+++ b/src/main/ipcBridge.ts
@@ -1620,6 +1620,13 @@ export function registerGlobalIpcHandlers() {
           }
         }
       });
+
+      // chokidar 在监听/遍历出错时会 emit "error"；若无监听器，EventEmitter 会把错误
+      // 抛成主进程 uncaughtException（例如 \\wsl.localhost\ 下对 Linux 软链接 lstat 返回
+      // EISDIR）。这里吞掉并记录，避免整个应用崩溃。
+      watcher.on("error", (error) => {
+        console.warn("[file:watch] watcher error:", error);
+      });
     }
 
     // 新增的文件 - 添加到 watcher
@@ -1671,6 +1678,12 @@ export function registerGlobalIpcHandlers() {
     directoryWatcher.on("unlink", notifyChanged);
     directoryWatcher.on("addDir", notifyChanged);
     directoryWatcher.on("unlinkDir", notifyChanged);
+    // chokidar 递归遍历目录时若对某个条目 lstat 失败会 emit "error"。典型场景：监听
+    // \\wsl.localhost\ (WSL/9P) 下的目录，对 Linux 软链接（如 *.so.0）lstat 返回 EISDIR。
+    // 没有该监听器时错误会冒泡为主进程 uncaughtException 导致崩溃，这里吞掉并记录。
+    directoryWatcher.on("error", (error) => {
+      console.warn("[workspace:watchDirectory] watcher error:", error);
+    });
   });
 
   // 停止监听目录

--- a/src/main/ipcBridge.ts
+++ b/src/main/ipcBridge.ts
@@ -5,7 +5,6 @@ import type { Block, ExportPDFOptions } from "./types";
 import type { FileTraits } from "./fileFormat";
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import chokidar from "chokidar";
@@ -35,6 +34,13 @@ import {
   updateWindowOpenFiles,
 } from "./windowManager";
 import type { TearOffTabData } from "./windowManager";
+import {
+  classifyWatchTarget,
+  partitionPaths,
+  scanDirectory,
+  WslDirectoryWatcher,
+  WslFileWatcher,
+} from "./wslWatch";
 
 /** 每个窗口独立追踪保存状态（windowId → isSaved） */
 const windowSaveState = new Map<number, boolean>();
@@ -52,6 +58,8 @@ export function setIsQuitting(value: boolean): void {
 function cleanupWindowState(windowId: number): void {
   windowSaveState.delete(windowId);
   windowClosingSet.delete(windowId);
+  // 窗口关闭：从 WSL 文件监听引用计数中移除（归零才真正 unwatchFile）
+  wslFileWatcher.removeWindow(windowId);
 }
 
 // 存储已监听的文件路径和对应的 watcher
@@ -62,6 +70,22 @@ let watcher: FSWatcher | null = null;
 let directoryWatcher: FSWatcher | null = null;
 let directoryChangedDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let imagePreviewWindow: BrowserWindow | null = null;
+
+// ── WSL/远程文件监听第二层（轮询路线，见 docs/spec-wsl-file-watching-layer2.md）──
+// 广播到所有编辑器窗口
+function broadcastToEditors(channel: string, ...args: unknown[]): void {
+  for (const editorWin of getEditorWindows()) {
+    if (!editorWin.isDestroyed()) editorWin.webContents.send(channel, ...args);
+  }
+}
+// WSL 远程目录：setInterval 轮询快照（fs.watch 在 9P 上启动即 EISDIR，不可用）
+const wslDirWatcher = new WslDirectoryWatcher({
+  onChanged: () => broadcastToEditors("workspace:directory-changed"),
+});
+// WSL 远程已打开文件：fs.watchFile 轮询 + 引用计数
+const wslFileWatcher = new WslFileWatcher({
+  onChanged: (filePath) => broadcastToEditors("file:changed", filePath),
+});
 
 interface ImagePreviewItem {
   src: string;
@@ -1187,6 +1211,16 @@ export function registerIpcHandleHandlers() {
 }
 // 无需 win 的 ipc 处理
 export function registerGlobalIpcHandlers() {
+  // WSL 第二层：窗口获得焦点时主动 stat 兜底（覆盖后台轮询被节流/切回窗口的时机，§4.4）
+  app.on("browser-window-focus", (_event, win) => {
+    void wslFileWatcher.checkWindow(win.id);
+  });
+  // 退出清理：fs.watchFile 的 StatWatcher 是 ref 句柄，残留会阻止进程正常退出（§4.2）
+  app.on("before-quit", () => {
+    wslFileWatcher.dispose();
+    wslDirWatcher.unwatchAll();
+  });
+
   ipcMain.handle("clipboard:writeText", async (_event, text: string): Promise<boolean> => {
     clipboard.writeText(text ?? "");
     return true;
@@ -1465,115 +1499,14 @@ export function registerGlobalIpcHandlers() {
     }
   });
 
-  // 获取目录下的文件列表（树形结构）
+  // 获取目录下的文件列表（树形结构）。WSL 远程目录会丢弃 symlink（读不透，见 wslWatch/§0-A）。
   ipcMain.handle("workspace:getDirectoryFiles", async (_event, dirPath: string) => {
     try {
       if (!dirPath || !fs.existsSync(dirPath)) {
         return [];
       }
-
-      interface WorkSpace {
-        name: string;
-        path: string;
-        isDirectory: boolean;
-        mtime: number;
-        children?: WorkSpace[];
-      }
-
-      // 性能优化配置
-      const MAX_DEPTH = 10; // 最大扫描深度
-      const MAX_FILES_PER_DIR = 100; // 每个目录最大文件数
-      const IGNORE_PATTERNS = [
-        /^\.git$/,
-        /^\.vscode$/,
-        /^\.idea$/,
-        /^node_modules$/,
-        /^\.next$/,
-        /^\.nuxt$/,
-        /^dist$/,
-        /^build$/,
-        /^coverage$/,
-        /^\.DS_Store$/,
-        /^Thumbs\.db$/,
-      ];
-
-      function shouldIgnoreDirectory(name: string): boolean {
-        return IGNORE_PATTERNS.some((pattern) => pattern.test(name));
-      }
-
-      function isSupportedWorkspaceFile(name: string): boolean {
-        return /\.(?:md|markdown|png|jpe?g|gif|webp|svg|bmp)$/i.test(name);
-      }
-
-      async function getMtimeMs(targetPath: string): Promise<number> {
-        try {
-          const stat = await fsp.stat(targetPath);
-          return stat.mtimeMs;
-        } catch {
-          return 0;
-        }
-      }
-
-      async function scanDirectory(currentPath: string, depth: number = 0): Promise<WorkSpace[]> {
-        // 限制扫描深度
-        if (depth > MAX_DEPTH) {
-          return [];
-        }
-
-        try {
-          const items = await fsp.readdir(currentPath, { withFileTypes: true });
-
-          // 限制每个目录的文件数量
-          if (items.length > MAX_FILES_PER_DIR) {
-            console.warn(`目录 ${currentPath} 包含过多文件 (${items.length})，已限制扫描`);
-            items.splice(MAX_FILES_PER_DIR);
-          }
-
-          // 先添加文件夹，再添加文件
-          const directories: WorkSpace[] = [];
-          const files: WorkSpace[] = [];
-
-          for (const item of items) {
-            const itemPath = path.join(currentPath, item.name);
-
-            if (item.isDirectory()) {
-              // 跳过忽略的目录
-              if (shouldIgnoreDirectory(item.name)) {
-                continue;
-              }
-
-              const children = await scanDirectory(itemPath, depth + 1);
-              const dirMtime = await getMtimeMs(itemPath);
-              directories.push({
-                name: item.name,
-                path: itemPath,
-                isDirectory: true,
-                mtime: dirMtime,
-                children,
-              });
-            } else if (item.isFile() && isSupportedWorkspaceFile(item.name)) {
-              const fileMtime = await getMtimeMs(itemPath);
-              files.push({
-                name: item.name,
-                path: itemPath,
-                isDirectory: false,
-                mtime: fileMtime,
-              });
-            }
-          }
-
-          // 按名称排序
-          directories.sort((a, b) => a.name.localeCompare(b.name));
-          files.sort((a, b) => a.name.localeCompare(b.name));
-
-          return [...directories, ...files];
-        } catch (error) {
-          console.warn(`扫描目录失败: ${currentPath}`, error);
-          return [];
-        }
-      }
-
-      return await scanDirectory(dirPath);
+      const isWslRemote = classifyWatchTarget(dirPath) === "wsl";
+      return await scanDirectory(dirPath, { isWslRemote });
     } catch (error) {
       console.error("获取目录文件失败:", error);
       return [];
@@ -1595,10 +1528,14 @@ export function registerGlobalIpcHandlers() {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) updateWindowOpenFiles(win.id, filePaths);
 
-    // 先差异对比
-    const newFiles = filePaths.filter((filePath) => !watchedFiles.has(filePath));
+    // 按来源分流：WSL 远程走轮询(per-window 引用计数)，本地/SMB 沿用 chokidar
+    const { wsl: wslPaths, chokidar: localPaths } = partitionPaths(filePaths);
+    if (win) wslFileWatcher.setWindowFiles(win.id, wslPaths);
+
+    // 以下仅处理本地/SMB 路径（chokidar）
+    const newFiles = localPaths.filter((filePath) => !watchedFiles.has(filePath));
     const removedFiles = Array.from(watchedFiles).filter(
-      (filePath) => !filePaths.includes(filePath)
+      (filePath) => !localPaths.includes(filePath)
     );
 
     // 如果 watcher 不存在，创建它并设置事件监听
@@ -1644,13 +1581,25 @@ export function registerGlobalIpcHandlers() {
 
   // 监听目录变化（用于文件列表自动刷新）
   ipcMain.on("workspace:watchDirectory", (_event, dirPath: string) => {
-    // 先关闭旧的 watcher
+    // 先关闭旧的 chokidar watcher
     if (directoryWatcher) {
       directoryWatcher.close();
       directoryWatcher = null;
     }
 
-    if (!dirPath || !fs.existsSync(dirPath)) return;
+    if (!dirPath || !fs.existsSync(dirPath)) {
+      wslDirWatcher.unwatchAll();
+      return;
+    }
+
+    // WSL 远程目录：setInterval 轮询，不创建 chokidar（fs.watch 在 9P 上启动即 EISDIR）
+    if (classifyWatchTarget(dirPath) === "wsl") {
+      wslDirWatcher.watch(dirPath);
+      return;
+    }
+
+    // 本地 / SMB：沿用 chokidar 实时监听
+    wslDirWatcher.unwatchAll();
 
     const IGNORE_DIRS =
       /(?:^|[/\\])(?:\.git|\.vscode|\.idea|node_modules|\.next|\.nuxt|dist|build|coverage)(?:[/\\]|$)/;
@@ -1688,6 +1637,7 @@ export function registerGlobalIpcHandlers() {
 
   // 停止监听目录
   ipcMain.on("workspace:unwatchDirectory", () => {
+    wslDirWatcher.unwatchAll();
     if (directoryWatcher) {
       directoryWatcher.close();
       directoryWatcher = null;

--- a/src/main/wslWatch.ts
+++ b/src/main/wslWatch.ts
@@ -1,0 +1,452 @@
+// wslWatch.ts
+// WSL/远程文件监听第二层：路径分流 + WSL 9P 轮询路线。
+// 设计约束：本模块【不依赖 electron】，所有外部副作用(广播/窗口)由回调注入，便于 node:test 单测。
+// 依据 docs/spec-wsl-file-watching-layer2.md，§0 前置实测已 PASS（2026-06-06）。
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import path from "node:path";
+
+// ============================================================
+// 纯函数（§4.0 路径判定 / 快照）
+// ============================================================
+
+/**
+ * 归一化路径前缀：
+ *  - `\\?\UNC\server\share\..` -> `\\server\share\..`
+ *  - `\\?\C:\..`               -> `C:\..`
+ * 否则原样返回。防止 `\\?\UNC\wsl.localhost\` 被误判为本地而重开 EISDIR（§4.0）。
+ */
+export function normalizeWatchPath(p: string): string {
+  if (!p) return p;
+  if (/^\\\\\?\\UNC\\/i.test(p)) return "\\\\" + p.slice(8); // 去掉 `\\?\UNC\`(8 字符)
+  if (/^\\\\\?\\[a-zA-Z]:\\/.test(p)) return p.slice(4); // 去掉 `\\?\`(4 字符)
+  return p;
+}
+
+export type WatchKind = "wsl" | "chokidar";
+
+/**
+ * 仅 `\\wsl.localhost\` / `\\wsl$\` 归一化后判为 "wsl"（走轮询）；
+ * 其余（本地盘符、SMB `\\server\share`、`Z:\` 映射、posix）一律 "chokidar"。
+ */
+export function classifyWatchTarget(p: string): WatchKind {
+  const n = normalizeWatchPath(p || "");
+  return /^\\\\wsl(?:\$|\.localhost)\\/i.test(n) ? "wsl" : "chokidar";
+}
+
+/** 把混合路径列表按来源分流，保证不重叠、无遗漏（§4.2 partition）。 */
+export function partitionPaths(paths: string[]): { wsl: string[]; chokidar: string[] } {
+  const wsl: string[] = [];
+  const chokidar: string[] = [];
+  for (const p of paths) {
+    if (classifyWatchTarget(p) === "wsl") wsl.push(p);
+    else chokidar.push(p);
+  }
+  return { wsl, chokidar };
+}
+
+/** 快照单元值：mtime 取整(避免浮点抖动) + size（§4.1 快照键 path+mtime+size）。 */
+export function snapshotEntry(mtimeMs: number, size: number): string {
+  return `${Math.trunc(mtimeMs)}:${size}`;
+}
+
+/** 两个快照(Map<path, "mtime:size">)是否有差异。 */
+export function snapshotChanged(prev: Map<string, string>, curr: Map<string, string>): boolean {
+  if (prev.size !== curr.size) return true;
+  for (const [k, v] of curr) {
+    if (prev.get(k) !== v) return true;
+  }
+  return false;
+}
+
+// ============================================================
+// 目录遍历（树构建 + 快照），与 chokidar 路径共用同一截断常量（§4.1 截断一致性）
+// ============================================================
+
+export const MAX_DEPTH = 10;
+export const MAX_FILES_PER_DIR = 100;
+
+const IGNORE_PATTERNS = [
+  /^\.git$/,
+  /^\.vscode$/,
+  /^\.idea$/,
+  /^node_modules$/,
+  /^\.next$/,
+  /^\.nuxt$/,
+  /^dist$/,
+  /^build$/,
+  /^coverage$/,
+  /^\.DS_Store$/,
+  /^Thumbs\.db$/,
+];
+
+export function shouldIgnoreDirectory(name: string): boolean {
+  return IGNORE_PATTERNS.some((p) => p.test(name));
+}
+
+export function isSupportedWorkspaceFile(name: string): boolean {
+  return /\.(?:md|markdown|png|jpe?g|gif|webp|svg|bmp)$/i.test(name);
+}
+
+export interface WorkspaceNode {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  isSymlink?: boolean;
+  mtime: number;
+  children?: WorkspaceNode[];
+}
+
+async function getMtimeMsSafe(p: string): Promise<number> {
+  try {
+    return (await fsp.stat(p)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * 构建文件树（替代原 ipcBridge 内联 scanDirectory）。
+ * symlink 处理按来源分流（§4.3，依 §0-A 实测缩范围）：
+ *  - 本地 / SMB：symlink 可 stat，受支持扩展名的 symlink 作为 inert 文件节点进树并标记；
+ *  - WSL 远程：symlink 从 Windows 侧读不透(lstat/stat 皆失败) → 丢弃，不进树。
+ * 不解引用递归（避免环；WSL 下更是平台强制 stat ENOENT）。
+ */
+export async function scanDirectory(
+  dirPath: string,
+  opts: { isWslRemote: boolean },
+  depth = 0
+): Promise<WorkspaceNode[]> {
+  if (depth > MAX_DEPTH) return [];
+
+  let items: fs.Dirent[];
+  try {
+    items = await fsp.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  if (items.length > MAX_FILES_PER_DIR) items.splice(MAX_FILES_PER_DIR);
+
+  const directories: WorkspaceNode[] = [];
+  const files: WorkspaceNode[] = [];
+
+  for (const item of items) {
+    const itemPath = path.join(dirPath, item.name);
+
+    if (item.isSymbolicLink()) {
+      // WSL：读不透，丢弃。本地/SMB：仅支持的扩展名作为 inert 节点进树。
+      if (opts.isWslRemote) continue;
+      if (!isSupportedWorkspaceFile(item.name)) continue;
+      const mtime = await getMtimeMsSafe(itemPath);
+      files.push({ name: item.name, path: itemPath, isDirectory: false, isSymlink: true, mtime });
+      continue;
+    }
+
+    if (item.isDirectory()) {
+      if (shouldIgnoreDirectory(item.name)) continue;
+      const children = await scanDirectory(itemPath, opts, depth + 1);
+      const mtime = await getMtimeMsSafe(itemPath);
+      directories.push({ name: item.name, path: itemPath, isDirectory: true, mtime, children });
+    } else if (item.isFile() && isSupportedWorkspaceFile(item.name)) {
+      const mtime = await getMtimeMsSafe(itemPath);
+      files.push({ name: item.name, path: itemPath, isDirectory: false, mtime });
+    }
+  }
+
+  directories.sort((a, b) => a.name.localeCompare(b.name));
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return [...directories, ...files];
+}
+
+/** 目录快照（用于变更检测）：path -> "mtime:size"。symlink 跳过（WSL 读不透）。 */
+export async function snapshotDirectory(dirPath: string): Promise<Map<string, string>> {
+  const snap = new Map<string, string>();
+
+  async function walk(cur: string, depth: number): Promise<void> {
+    if (depth > MAX_DEPTH) return;
+    let items: fs.Dirent[];
+    try {
+      items = await fsp.readdir(cur, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    if (items.length > MAX_FILES_PER_DIR) items.splice(MAX_FILES_PER_DIR);
+    for (const it of items) {
+      if (it.isSymbolicLink()) continue;
+      const ip = path.join(cur, it.name);
+      if (it.isDirectory()) {
+        if (shouldIgnoreDirectory(it.name)) continue;
+        try {
+          const st = await fsp.stat(ip);
+          snap.set(ip, snapshotEntry(st.mtimeMs, st.size));
+        } catch {
+          /* 跳过 */
+        }
+        await walk(ip, depth + 1);
+      } else if (it.isFile() && isSupportedWorkspaceFile(it.name)) {
+        try {
+          const st = await fsp.stat(ip);
+          snap.set(ip, snapshotEntry(st.mtimeMs, st.size));
+        } catch {
+          /* 跳过 */
+        }
+      }
+    }
+  }
+
+  await walk(dirPath, 0);
+  return snap;
+}
+
+// ============================================================
+// WSL 目录轮询（§4.1）
+// ============================================================
+
+export interface WslDirWatcherOptions {
+  intervalMs?: number; // 远程文件树轮询间隔，默认 4000（§5）
+  debounceMs?: number; // 广播去抖，默认 300（对齐本地）
+  snapshot?: (dirPath: string) => Promise<Map<string, string>>;
+  exists?: (dirPath: string) => boolean | Promise<boolean>; // 可达性判别
+  onChanged: () => void; // 广播 workspace:directory-changed（已内部去抖）
+}
+
+interface DirState {
+  timer: ReturnType<typeof setInterval> | null;
+  epoch: number;
+  inFlight: boolean;
+  snapshot: Map<string, string> | null;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class WslDirectoryWatcher {
+  private dirs = new Map<string, DirState>();
+  private intervalMs: number;
+  private debounceMs: number;
+  private snapshotFn: (dirPath: string) => Promise<Map<string, string>>;
+  private existsFn: (dirPath: string) => boolean | Promise<boolean>;
+  private onChanged: () => void;
+
+  constructor(opts: WslDirWatcherOptions) {
+    this.intervalMs = opts.intervalMs ?? 4000;
+    this.debounceMs = opts.debounceMs ?? 300;
+    this.snapshotFn = opts.snapshot ?? snapshotDirectory;
+    this.existsFn =
+      opts.exists ??
+      (async (p: string) => {
+        try {
+          await fsp.access(p);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    this.onChanged = opts.onChanged;
+  }
+
+  /** 监听某 WSL 目录。入口先自清旧 interval（对称 chokidar close），再建新的并立即建立基线快照。 */
+  watch(dirPath: string): void {
+    this.unwatch(dirPath);
+    const state: DirState = {
+      timer: null,
+      epoch: 0,
+      inFlight: false,
+      snapshot: null,
+      debounceTimer: null,
+    };
+    this.dirs.set(dirPath, state);
+    state.timer = setInterval(() => void this.tick(dirPath), this.intervalMs);
+    void this.tick(dirPath, true); // 基线：建立首个快照，不广播
+  }
+
+  private async tick(dirPath: string, baseline = false): Promise<void> {
+    const state = this.dirs.get(dirPath);
+    if (!state) return;
+    if (state.inFlight) return; // in-flight guard：上一轮未完跳过本轮
+    state.inFlight = true;
+    const epoch = state.epoch;
+    try {
+      const reachable = await this.existsFn(dirPath);
+      let curr: Map<string, string>;
+      try {
+        curr = await this.snapshotFn(dirPath);
+      } catch {
+        return; // 扫描整体失败：保持旧快照，不广播
+      }
+      // 迟到结果丢弃：unwatch/重建后此 state 已失效
+      if (this.dirs.get(dirPath) !== state || epoch !== state.epoch) return;
+      // 不可达判别：上次快照非空 + 现在不可达且扫不到东西 -> 保持快照，不广播全删（§4.1）
+      if (!reachable && state.snapshot && state.snapshot.size > 0 && curr.size === 0) return;
+      const prev = state.snapshot;
+      state.snapshot = curr;
+      if (!baseline && prev && snapshotChanged(prev, curr)) {
+        this.scheduleBroadcast(state);
+      }
+    } finally {
+      state.inFlight = false;
+    }
+  }
+
+  private scheduleBroadcast(state: DirState): void {
+    if (state.debounceTimer) clearTimeout(state.debounceTimer);
+    state.debounceTimer = setTimeout(() => {
+      state.debounceTimer = null;
+      this.onChanged();
+    }, this.debounceMs);
+  }
+
+  unwatch(dirPath: string): void {
+    const state = this.dirs.get(dirPath);
+    if (!state) return;
+    state.epoch++; // 作废可能在途的迟到回调
+    if (state.timer) clearInterval(state.timer);
+    if (state.debounceTimer) clearTimeout(state.debounceTimer);
+    this.dirs.delete(dirPath);
+  }
+
+  unwatchAll(): void {
+    // 遍历时删除当前 key 在 JS Map 上是安全的（已访问/当前项删除不影响后续）
+    for (const k of this.dirs.keys()) this.unwatch(k);
+  }
+
+  get size(): number {
+    return this.dirs.size;
+  }
+}
+
+// ============================================================
+// WSL 已打开文件监听（§4.2 / §4.4）
+// ============================================================
+
+type StatLite = { mtimeMs: number; size: number };
+
+export interface WslFileWatcherOptions {
+  intervalMs?: number; // 单文件 mtime 轮询间隔，默认 1500（§5）
+  onChanged: (filePath: string) => void; // 广播 file:changed
+  watchFile?: (
+    file: string,
+    opts: { interval: number },
+    cb: (curr: fs.Stats, prev: fs.Stats) => void
+  ) => void;
+  unwatchFile?: (file: string, cb: (curr: fs.Stats, prev: fs.Stats) => void) => void;
+  stat?: (file: string) => Promise<StatLite | null>;
+}
+
+interface FileEntry {
+  cb: (curr: fs.Stats, prev: fs.Stats) => void;
+  last: string; // 上次已知 "mtime:size"
+}
+
+export class WslFileWatcher {
+  private byWindow = new Map<number, Set<string>>();
+  private watching = new Map<string, FileEntry>();
+  private intervalMs: number;
+  private onChanged: (filePath: string) => void;
+  private watchFileFn: NonNullable<WslFileWatcherOptions["watchFile"]>;
+  private unwatchFileFn: NonNullable<WslFileWatcherOptions["unwatchFile"]>;
+  private statFn: NonNullable<WslFileWatcherOptions["stat"]>;
+
+  constructor(opts: WslFileWatcherOptions) {
+    this.intervalMs = opts.intervalMs ?? 1500;
+    this.onChanged = opts.onChanged;
+    this.watchFileFn = opts.watchFile ?? ((f, o, cb) => fs.watchFile(f, o, cb));
+    this.unwatchFileFn = opts.unwatchFile ?? ((f, cb) => fs.unwatchFile(f, cb));
+    this.statFn =
+      opts.stat ??
+      (async (f: string) => {
+        try {
+          const st = await fsp.stat(f);
+          return { mtimeMs: st.mtimeMs, size: st.size };
+        } catch {
+          return null;
+        }
+      });
+  }
+
+  /** 某窗口当前打开的 WSL 文件全集（替换式）。多窗口经 union 做引用计数。 */
+  setWindowFiles(windowId: number, wslPaths: string[]): void {
+    this.byWindow.set(windowId, new Set(wslPaths));
+    this.reconcile();
+  }
+
+  removeWindow(windowId: number): void {
+    if (this.byWindow.delete(windowId)) this.reconcile();
+  }
+
+  private union(): Set<string> {
+    const u = new Set<string>();
+    for (const s of this.byWindow.values()) for (const p of s) u.add(p);
+    return u;
+  }
+
+  private reconcile(): void {
+    const u = this.union();
+    for (const p of u) if (!this.watching.has(p)) this.startWatch(p);
+    // 遍历时删除当前 key 在 JS Map 上安全
+    for (const p of this.watching.keys()) if (!u.has(p)) this.stopWatch(p);
+  }
+
+  private startWatch(p: string): void {
+    const entry: FileEntry = { cb: () => {}, last: "" };
+    entry.cb = (curr: fs.Stats) => {
+      // mtime=0 => 文件消失：不广播（renderer 读会失败）；等重建后(mtime>0)再正常报（§4.2）
+      if (!curr || curr.mtimeMs === 0) {
+        entry.last = "";
+        return;
+      }
+      const key = snapshotEntry(curr.mtimeMs, curr.size);
+      if (key === entry.last) return;
+      entry.last = key;
+      this.onChanged(p);
+    };
+    this.watching.set(p, entry);
+    this.watchFileFn(p, { interval: this.intervalMs }, entry.cb);
+    void this.seed(p, entry); // 建立基线，避免 focus 兜底首次误报
+  }
+
+  private async seed(p: string, entry: FileEntry): Promise<void> {
+    try {
+      const st = await this.statFn(p);
+      if (st && st.mtimeMs !== 0 && entry.last === "") {
+        entry.last = snapshotEntry(st.mtimeMs, st.size);
+      }
+    } catch {
+      /* 忽略 */
+    }
+  }
+
+  private stopWatch(p: string): void {
+    const e = this.watching.get(p);
+    if (!e) return;
+    this.unwatchFileFn(p, e.cb);
+    this.watching.delete(p);
+  }
+
+  /** §4.4 focus 兜底：窗口获得焦点时主动 stat 该窗口的 WSL 文件，变化即报。 */
+  async checkWindow(windowId: number): Promise<void> {
+    const set = this.byWindow.get(windowId);
+    if (!set) return;
+    for (const p of set) {
+      const e = this.watching.get(p);
+      if (!e) continue;
+      const st = await this.statFn(p);
+      if (!st || st.mtimeMs === 0) continue;
+      const key = snapshotEntry(st.mtimeMs, st.size);
+      if (key !== e.last) {
+        e.last = key;
+        this.onChanged(p);
+      }
+    }
+  }
+
+  /** 退出清理：StatWatcher 是 ref 句柄，残留会阻止进程退出（§4.2）。 */
+  dispose(): void {
+    for (const [p, e] of this.watching) this.unwatchFileFn(p, e.cb);
+    this.watching.clear();
+    this.byWindow.clear();
+  }
+
+  get size(): number {
+    return this.watching.size;
+  }
+}

--- a/src/renderer/hooks/useWorkSpace.ts
+++ b/src/renderer/hooks/useWorkSpace.ts
@@ -20,7 +20,6 @@ interface WorkSpace {
 
 const workSpace = ref<WorkSpace[] | null>(null);
 const watchedDirPath = ref<string | null>(null);
-let hasShownRemoteWorkspaceSkipToast = false;
 
 // 搜索
 const searchQuery = ref("");
@@ -95,13 +94,7 @@ async function getWorkSpace() {
   // 获取文件所在的目录路径
   const directoryPath = realFile.filePath.replace(/[^/\\]+$/, "");
 
-  if (!shouldAutoLoadWorkspace(directoryPath)) {
-    if (!hasShownRemoteWorkspaceSkipToast) {
-      hasShownRemoteWorkspaceSkipToast = true;
-      toast.show("检测到 WSL / 远程路径，已跳过自动加载工作区，可手动打开文件夹", "info");
-    }
-    return;
-  }
+  if (!shouldAutoLoadWorkspace(directoryPath)) return;
 
   try {
     isLoading.value = true;
@@ -109,13 +102,13 @@ async function getWorkSpace() {
     const result = await window.electronAPI.getDirectoryFiles(directoryPath);
 
     if (!result) return;
-    if (!result.length) return;
 
-    // 已加载
+    // 已加载。注意：远程(WSL)首扫慢 / 全 symlink 时可能返回空数组——空数组也置位并开始监听，
+    // 否则 isLoadWorkSpace 不置位 → tabs 变化反复整树重扫拖慢 9P（§4.3 空树锁）。
     isLoadWorkSpace = true;
     // 更新文件夹信息
     workSpace.value = result;
-    // 开始监听目录
+    // 开始监听目录（远程的周期刷新由 main 进程的轮询 interval 负责）
     startWatching(directoryPath);
   } catch {
     toast.show("获取目录文件失败:", "error");
@@ -179,8 +172,12 @@ function stopWatching() {
 }
 
 // 刷新文件列表
+let isRefreshing = false;
 async function refreshWorkSpace() {
   if (!watchedDirPath.value) return;
+  // 与下一轮轮询 interval / 重复的 directory-changed 互斥：刷新进行中不叠加新刷新（§4.1）
+  if (isRefreshing) return;
+  isRefreshing = true;
   try {
     const result = await window.electronAPI.getDirectoryFiles(watchedDirPath.value);
     if (result) {
@@ -188,6 +185,8 @@ async function refreshWorkSpace() {
     }
   } catch {
     // 静默失败
+  } finally {
+    isRefreshing = false;
   }
 }
 

--- a/src/renderer/utils/workspacePath.ts
+++ b/src/renderer/utils/workspacePath.ts
@@ -22,6 +22,10 @@ export function isRemoteWorkspacePath(pathValue: string): boolean {
   return /^\\\\wsl(?:\$|\.localhost)\\/i.test(pathValue) || /^\\\\(?![?.]\\)/.test(pathValue);
 }
 
+// 第二层（layer2）：§0-A 实测证明 WSL/远程目录建树路径安全（readdir d_type 分类 + 真实
+// dir/file stat 正常，不再 EISDIR），故撤销第一层的"远程跳过"——远程也自动加载文件树。
+// 监听方式（本地/SMB 走 chokidar、WSL 走轮询）由 main 进程按路径分流，见 src/main/wslWatch.ts。
+// isRemoteWorkspacePath 保留作远程路径判定工具（仍可被其他逻辑复用）。
 export function shouldAutoLoadWorkspace(pathValue: string): boolean {
-  return Boolean(pathValue) && !isRemoteWorkspacePath(pathValue);
+  return Boolean(pathValue);
 }

--- a/src/renderer/utils/workspacePath.ts
+++ b/src/renderer/utils/workspacePath.ts
@@ -10,8 +10,14 @@ export function isAbsoluteLocalPath(pathValue: string): boolean {
   return pathValue.startsWith("/");
 }
 
+// 注意：本模块在渲染进程执行（nodeIntegration:false），渲染进程里 process.platform 不可用，
+// platform.ts 的 isWindows 会恒为 false。因此这里【不能】用 isWindows 做前置短路，否则本防护
+// 会永远失效——曾导致打开 WSL 文件时仍自动加载工作区，进而对 \\wsl.localhost\ 下的 Linux 软链接
+// （如 librockchip_mpp.so.0）lstat 触发 EISDIR，使主进程未捕获异常崩溃。
+// UNC 路径（\\wsl.localhost\、\\wsl$\、\\server\share）本身是 Windows 专有写法，不会出现在其他
+// 平台的合法路径里，无需平台判断即可安全识别为远程路径。
 export function isRemoteWorkspacePath(pathValue: string): boolean {
-  if (!pathValue || !isWindows) return false;
+  if (!pathValue) return false;
 
   return /^\\\\wsl(?:\$|\.localhost)\\/i.test(pathValue) || /^\\\\(?![?.]\\)/.test(pathValue);
 }

--- a/test/wsl-l2.test.mjs
+++ b/test/wsl-l2.test.mjs
@@ -1,0 +1,124 @@
+// WSL/远程文件监听第二层 —— 纯函数单元测试
+// 运行: node --experimental-strip-types --test test/wsl-l2.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeWatchPath,
+  classifyWatchTarget,
+  partitionPaths,
+  snapshotEntry,
+  snapshotChanged,
+} from "../src/main/wslWatch.ts";
+
+test("normalizeWatchPath: 还原 \\\\?\\UNC\\ 前缀为 \\\\", () => {
+  assert.equal(
+    normalizeWatchPath("\\\\?\\UNC\\wsl.localhost\\Debian11\\tmp\\x"),
+    "\\\\wsl.localhost\\Debian11\\tmp\\x"
+  );
+  assert.equal(normalizeWatchPath("\\\\?\\UNC\\server\\share\\a"), "\\\\server\\share\\a");
+});
+
+test("normalizeWatchPath: 还原 \\\\?\\C:\\ 前缀为盘符", () => {
+  assert.equal(normalizeWatchPath("\\\\?\\C:\\Users\\x"), "C:\\Users\\x");
+});
+
+test("normalizeWatchPath: 普通路径原样返回", () => {
+  assert.equal(normalizeWatchPath("C:\\Users\\x"), "C:\\Users\\x");
+  assert.equal(
+    normalizeWatchPath("\\\\wsl.localhost\\Debian11\\a"),
+    "\\\\wsl.localhost\\Debian11\\a"
+  );
+  assert.equal(normalizeWatchPath("/home/user/a"), "/home/user/a");
+  assert.equal(normalizeWatchPath(""), "");
+});
+
+test("classifyWatchTarget: WSL UNC -> wsl", () => {
+  assert.equal(classifyWatchTarget("\\\\wsl.localhost\\Debian11\\tmp"), "wsl");
+  assert.equal(classifyWatchTarget("\\\\wsl$\\Ubuntu-22.04\\home"), "wsl");
+});
+
+test("classifyWatchTarget: 大小写不敏感", () => {
+  assert.equal(classifyWatchTarget("\\\\WSL.LOCALHOST\\Debian11\\x"), "wsl");
+  assert.equal(classifyWatchTarget("\\\\WSL$\\Ubuntu\\x"), "wsl");
+});
+
+test("classifyWatchTarget: \\\\?\\UNC\\wsl 归一化后仍判 wsl(防重开 EISDIR)", () => {
+  assert.equal(classifyWatchTarget("\\\\?\\UNC\\wsl.localhost\\Debian11\\x"), "wsl");
+});
+
+test("classifyWatchTarget: SMB / 本地盘符 / Z: 映射 / posix -> chokidar", () => {
+  assert.equal(classifyWatchTarget("\\\\server\\share\\a"), "chokidar"); // SMB
+  assert.equal(classifyWatchTarget("C:\\Users\\x"), "chokidar"); // 本地盘符
+  assert.equal(classifyWatchTarget("Z:\\foo"), "chokidar"); // 已知漏判: net use 映射的 WSL
+  assert.equal(classifyWatchTarget("/home/user/a"), "chokidar"); // posix
+  assert.equal(classifyWatchTarget(""), "chokidar");
+});
+
+test("classifyWatchTarget: 名字里含 wsl 的 SMB 主机不应误判", () => {
+  // \\wslserver\share 不是 \\wsl.localhost / \\wsl$ , 应判 chokidar
+  assert.equal(classifyWatchTarget("\\\\wslserver\\share\\a"), "chokidar");
+});
+
+test("partitionPaths: 混合列表正确分流且不重叠不遗漏", () => {
+  const input = [
+    "C:\\a.md",
+    "\\\\wsl.localhost\\Debian11\\a.md",
+    "\\\\server\\share\\b.md",
+    "\\\\wsl$\\Ubuntu\\c.md",
+  ];
+  const { wsl, chokidar } = partitionPaths(input);
+  assert.deepEqual(wsl, ["\\\\wsl.localhost\\Debian11\\a.md", "\\\\wsl$\\Ubuntu\\c.md"]);
+  assert.deepEqual(chokidar, ["C:\\a.md", "\\\\server\\share\\b.md"]);
+  assert.equal(wsl.length + chokidar.length, input.length);
+});
+
+test("snapshotEntry: mtime 取整 + 拼 size", () => {
+  assert.equal(snapshotEntry(1591394766000.7, 25), "1591394766000:25");
+});
+
+test("snapshotChanged: 同集合 -> false", () => {
+  const a = new Map([
+    ["/x", "100:10"],
+    ["/y", "200:20"],
+  ]);
+  const b = new Map([
+    ["/x", "100:10"],
+    ["/y", "200:20"],
+  ]);
+  assert.equal(snapshotChanged(a, b), false);
+});
+
+test("snapshotChanged: mtime 变 -> true", () => {
+  const a = new Map([["/x", "100:10"]]);
+  const b = new Map([["/x", "999:10"]]);
+  assert.equal(snapshotChanged(a, b), true);
+});
+
+test("snapshotChanged: 同 mtime 仅 size 变 -> true(对齐 §0-B)", () => {
+  const a = new Map([["/x", "100:10"]]);
+  const b = new Map([["/x", "100:25"]]);
+  assert.equal(snapshotChanged(a, b), true);
+});
+
+test("snapshotChanged: 新增/删除 key -> true", () => {
+  assert.equal(
+    snapshotChanged(
+      new Map([["/x", "1:1"]]),
+      new Map([
+        ["/x", "1:1"],
+        ["/y", "2:2"],
+      ])
+    ),
+    true
+  );
+  assert.equal(
+    snapshotChanged(
+      new Map([
+        ["/x", "1:1"],
+        ["/y", "2:2"],
+      ]),
+      new Map([["/x", "1:1"]])
+    ),
+    true
+  );
+});

--- a/test/wsl-watchers.test.mjs
+++ b/test/wsl-watchers.test.mjs
@@ -1,0 +1,150 @@
+// WslFileWatcher / WslDirectoryWatcher 行为测试（注入假依赖，不依赖 electron）
+// 运行: node --experimental-strip-types --test test/wsl-watchers.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import { WslFileWatcher, WslDirectoryWatcher } from "../src/main/wslWatch.ts";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeFileHarness() {
+  const cbs = new Map(); // path -> cb
+  const watched = new Set();
+  const changes = [];
+  const w = new WslFileWatcher({
+    intervalMs: 1,
+    onChanged: (p) => changes.push(p),
+    watchFile: (f, _o, cb) => {
+      cbs.set(f, cb);
+      watched.add(f);
+    },
+    unwatchFile: (f) => {
+      cbs.delete(f);
+      watched.delete(f);
+    },
+    stat: async () => null, // seed 不干扰（last 保持 ""）
+  });
+  return { w, cbs, watched, changes };
+}
+
+test("WslFileWatcher: setWindowFiles 启停监听", () => {
+  const { w, watched } = makeFileHarness();
+  w.setWindowFiles(1, ["\\\\wsl.localhost\\D\\a.md", "\\\\wsl.localhost\\D\\b.md"]);
+  assert.equal(watched.size, 2);
+  w.setWindowFiles(1, ["\\\\wsl.localhost\\D\\a.md"]);
+  assert.equal(watched.size, 1);
+  assert.ok(watched.has("\\\\wsl.localhost\\D\\a.md"));
+});
+
+test("WslFileWatcher: 多窗口同文件 union 引用计数，归零才 unwatch", () => {
+  const { w, watched } = makeFileHarness();
+  const f = "\\\\wsl.localhost\\D\\shared.md";
+  w.setWindowFiles(1, [f]);
+  w.setWindowFiles(2, [f]);
+  assert.equal(watched.size, 1); // 同一文件只监听一次
+  w.removeWindow(1);
+  assert.ok(watched.has(f)); // 窗口2 还开着 -> 不 unwatch
+  w.removeWindow(2);
+  assert.equal(watched.size, 0); // 归零才 unwatch
+});
+
+test("WslFileWatcher: 变更触发 onChanged，同 key 不重复，mtime=0 不报", () => {
+  const { w, cbs, changes } = makeFileHarness();
+  const f = "\\\\wsl.localhost\\D\\a.md";
+  w.setWindowFiles(1, [f]);
+  const cb = cbs.get(f);
+  cb({ mtimeMs: 100, size: 10 }); // 首次变更
+  cb({ mtimeMs: 100, size: 10 }); // 同 key -> 不重复
+  cb({ mtimeMs: 200, size: 10 }); // mtime 变
+  cb({ mtimeMs: 0, size: 0 }); // 删除 -> 不报
+  cb({ mtimeMs: 300, size: 5 }); // 重建后再报
+  assert.deepEqual(changes, [f, f, f]);
+});
+
+test("WslFileWatcher: checkWindow(focus) 比对 stat 变化即报", async () => {
+  const cbs = new Map();
+  const changes = [];
+  let statVal = { mtimeMs: 100, size: 10 };
+  const w = new WslFileWatcher({
+    intervalMs: 1,
+    onChanged: (p) => changes.push(p),
+    watchFile: (f, _o, cb) => cbs.set(f, cb),
+    unwatchFile: (f) => cbs.delete(f),
+    stat: async () => statVal,
+  });
+  const f = "\\\\wsl.localhost\\D\\a.md";
+  w.setWindowFiles(1, [f]);
+  await sleep(5); // 等 seed 完成，last = "100:10"
+  await w.checkWindow(1); // 无变化 -> 不报
+  assert.equal(changes.length, 0);
+  statVal = { mtimeMs: 100, size: 25 }; // 同 mtime 改 size
+  await w.checkWindow(1);
+  assert.deepEqual(changes, [f]);
+});
+
+test("WslFileWatcher: dispose 清空所有监听", () => {
+  const { w, watched } = makeFileHarness();
+  w.setWindowFiles(1, ["\\\\wsl.localhost\\D\\a.md", "\\\\wsl.localhost\\D\\b.md"]);
+  assert.equal(watched.size, 2);
+  w.dispose();
+  assert.equal(watched.size, 0);
+  assert.equal(w.size, 0);
+});
+
+test("WslDirectoryWatcher: 快照变化触发 onChanged(去抖后)", async () => {
+  let snap = new Map([["/x", "1:1"]]);
+  let calls = 0;
+  const w = new WslDirectoryWatcher({
+    intervalMs: 15,
+    debounceMs: 5,
+    snapshot: async () => new Map(snap),
+    exists: async () => true,
+    onChanged: () => calls++,
+  });
+  w.watch("\\\\wsl.localhost\\D\\dir");
+  await sleep(40); // 基线 + 若干 tick，无变化
+  assert.equal(calls, 0);
+  snap = new Map([
+    ["/x", "1:1"],
+    ["/y", "2:2"],
+  ]); // 新增文件
+  await sleep(60);
+  assert.ok(calls >= 1, `期望 onChanged 至少 1 次, 实际 ${calls}`);
+  w.unwatchAll();
+});
+
+test("WslDirectoryWatcher: 不可达(exists=false)且扫空时不广播全删", async () => {
+  let snap = new Map([
+    ["/x", "1:1"],
+    ["/y", "2:2"],
+  ]);
+  let reachable = true;
+  let calls = 0;
+  const w = new WslDirectoryWatcher({
+    intervalMs: 15,
+    debounceMs: 5,
+    snapshot: async () => new Map(snap),
+    exists: async () => reachable,
+    onChanged: () => calls++,
+  });
+  w.watch("\\\\wsl.localhost\\D\\dir");
+  await sleep(40); // 基线建立(快照非空)
+  reachable = false; // WSL shutdown
+  snap = new Map(); // readdir 扫不到
+  await sleep(60);
+  assert.equal(calls, 0, "不可达时不应广播全删");
+  w.unwatchAll();
+});
+
+test("WslDirectoryWatcher: unwatch 后停止；size 归零", async () => {
+  const w = new WslDirectoryWatcher({
+    intervalMs: 15,
+    debounceMs: 5,
+    snapshot: async () => new Map(),
+    exists: async () => true,
+    onChanged: () => {},
+  });
+  w.watch("\\\\wsl.localhost\\D\\dir");
+  assert.equal(w.size, 1);
+  w.unwatch("\\\\wsl.localhost\\D\\dir");
+  assert.equal(w.size, 0);
+});


### PR DESCRIPTION
> **本 PR 堆叠在 #236（第一层修复）之上。** 在 #236 合入前，本 PR 的 diff 会包含 #236 的那个提交（`fix: 修复打开 WSL 文件时主进程因 EISDIR 崩溃`）。**请先审阅 / 合并 #236**；#236 合入后本 PR 的 diff 会自动收敛为只剩第二层改动。

## 概述

第一层（#236）止血：打开 `\\wsl.localhost\` 下的文件不再因 `EISDIR` 崩溃，代价是 WSL 路径被跳过自动加载——没有左侧文件树、也不提示外部变更。

第二层（本 PR）恢复功能：让 WSL/远程文件也能 (1) 显示左侧文件树；(2) 外部进程修改文件时重新加载。

## 为什么 WSL 走轮询

在 `\\wsl.localhost\`（9P）上实测：

| 方式 | 结果 |
|------|------|
| `fs.watch`（chokidar 底层） | 启动即 `EISDIR`，不可用 |
| `fs.watchFile`（Node 轮询） | 可靠检测追加 / 原子替换 / 同 mtime 改 size / 删除 / 重建 |
| `readdir({withFileTypes})` + `stat` | 正常（不踩 EISDIR） |

因此按路径分流：**仅 `\\wsl.localhost\` / `\\wsl$\` 走轮询；本地与 SMB 保持 chokidar 实时，不退化。**

## 前置实测结论（spec §0，已 PASS）

- **建树安全**：生产 `scanDirectory` 在含 symlink / `.so` 链 / 大目录 / 深目录的真实 WSL 目录上建树，0 EISDIR / 0 uncaught（`readdir` 用 d_type 分类不 `lstat`；真实 dir/file 的 `stat` 正常）。
- **`fs.watchFile` 在 9P 可靠**：含"同 mtime 仅改 size"也能检出（比较含 size）、删除回调 `mtime=0`、删后重建跟踪存活。
- **WSL symlink 从 Windows 侧读不透**：`lstat`/`readlink`→EISDIR，`stat`/`readFile`→ENOENT（与相对/绝对、指向文件/目录无关）。故 WSL 分支**丢弃 symlink**（本地/SMB 仍正常显示）。

## 实现要点

- `src/main/wslWatch.ts`（新增，不依赖 electron，回调注入便于单测）：
  - 路径分流 `classifyWatchTarget` + `normalizeWatchPath`（还原 `\\?\UNC\` 前缀，防误判重开 EISDIR）；
  - `scanDirectory`（WSL 丢弃 symlink；本地/SMB 加 `isSymbolicLink()` 分支）；
  - `WslDirectoryWatcher`：per-dir `setInterval` + in-flight guard + epoch 丢弃迟到结果 + 快照(path+mtime+size) diff + 不可达不清树 + 300ms 去抖；
  - `WslFileWatcher`：per-window union 引用计数 + `fs.watchFile` + `mtime=0` 删除语义 + size 兜底 + 窗口 focus 主动比对兜底 + `before-quit` 清理句柄。
- `src/main/ipcBridge.ts`：`watchDirectory` / `file:watch` 按 classify 分流；`getDirectoryFiles` 改用模块 `scanDirectory`；`browser-window-focus` / `before-quit` / 窗口关闭清理。
- `src/renderer/utils/workspacePath.ts`：`shouldAutoLoadWorkspace` 撤销对远程的跳过（§0 已证建树安全）。
- `src/renderer/hooks/useWorkSpace.ts`：远程空树也置加载锁（避免 tabs 变化反复整树重扫拖慢 9P）；`refreshWorkSpace` 加 in-flight 互斥。

## 测试

- `node:test` 22 个（纯函数 + 两个 watcher 管理器，注入假依赖）全过；新增 `pnpm test` 脚本。
- 真机集成：用真实 `fs.watchFile` + `snapshotDirectory` 在真 `\\wsl.localhost\` 上验证目录增删 / 文件追加替换 / focus / 引用计数，9/9 通过。

## 已知局限（文档化，不在本层解决）

- WSL symlink 读不透，文件树不显示 symlink；其重指向不可感知。
- 本地树内嵌指向 WSL 的 junction/symlink、`Z:\` 等映射盘：靠第一层 error handler 兜底。
- 大仓首次建树有秒级延迟（9P + 节点数），属预期（spec §5：刷新延迟 ≈ 间隔 + scan 耗时）。
- 未编辑文件的外部变更沿用 milkup 既有"静默重载"行为（有未保存编辑时才弹确认框）。

完整设计与评审记录见 `docs/spec-wsl-file-watching-layer2.md`。
