### PR TITLE
docs: 修复 README 中 Star 历史图表不显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ milkup 致力于为用户提供高效、简洁的 Markdown 编辑体验。我们
 
 ## ⭐️ Star 历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=Auto-Plugin/milkup&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=Auto-Plugin/milkup&type=Date)
 
 ##  联系我们
 


### PR DESCRIPTION
README 中的 Star 历史图表目前无法正常显示，原因是原图表接口受限于 GitHub 的 API 限制已经失效。

本 PR 将 Star 历史图表切换到新的服务，无需 API Token 即可正常展示项目星标趋势。修复后图表即可恢复显示。